### PR TITLE
Fix minor typos and installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install "git+https://github.com/pytorch/functorch.git"
 Go to the directory where you have cloned the torchrl repo and install it
 ```
 cd /path/to/torchrl/
-python setup.py install
+python setup.py develop
 ```
 To run a quick sanity check, leave that directory and try to import the library.
 ```
@@ -111,7 +111,7 @@ pip install pytest
 
 **Troubleshooting**
 
-If a `ModuleNotFoundError: No module named ‘torchrl._torchrl` errors occurs, it means that the C++ extensions were not installed. This may be caused by several dependency issues: cmake, gcc or ninja versioning, or absence of the CuDNN library when working in a CUDA environment. Os MacOs, we recommend installing XCode first.
+If a `ModuleNotFoundError: No module named ‘torchrl._torchrl` errors occurs, it means that the C++ extensions were not installed. This may be caused by several dependency issues: cmake, gcc or ninja versioning, or absence of the CuDNN library when working in a CUDA environment. On MacOs, we recommend installing XCode first.
 
 ## Running examples
 Examples are coded in a very similar way but the configuration may change from one algorithm to another (e.g. async/sync data collection, hyperparameters, ratio of model updates / frame etc.)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,15 @@ pip install pytest
 
 **Troubleshooting**
 
-If a `ModuleNotFoundError: No module named ‘torchrl._torchrl` errors occurs, it means that the C++ extensions were not installed. This may be caused by several dependency issues: cmake, gcc or ninja versioning, or absence of the CuDNN library when working in a CUDA environment. On MacOs, we recommend installing XCode first.
+If a `ModuleNotFoundError: No module named ‘torchrl._torchrl` errors occurs, it means that the C++ extensions were not installed or not found. 
+One common reason might be that you are trying to import torchrl from within the git repo location. Indeed the following code snippet should return an error if torchrl has not been installed in `develop` mode:
+```
+cd ~/path/to/rl/repo
+python -c 'from torchrl.envs import GymEnv'
+```
+If this is the case, consider executing torchrl from another location.
+
+This may also be caused by several dependency issues: cmake, gcc or ninja versioning, or absence of the CuDNN library when working in a CUDA environment. On MacOs, we recommend installing XCode first.
 
 ## Running examples
 Examples are coded in a very similar way but the configuration may change from one algorithm to another (e.g. async/sync data collection, hyperparameters, ratio of model updates / frame etc.)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install "git+https://github.com/pytorch/functorch.git"
 Go to the directory where you have cloned the torchrl repo and install it
 ```
 cd /path/to/torchrl/
-python setup.py develop
+python setup.py install
 ```
 To run a quick sanity check, leave that directory and try to import the library.
 ```


### PR DESCRIPTION
"python setup.py install" actually has installation errors
either "python setup.py develop" or "pip install -e ."