### PR TITLE
Record exploration rollouts

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -188,7 +188,7 @@ class Transform(nn.Module):
 
         return reward_spec
 
-    def dump(self) -> None:
+    def dump(self, **kwargs) -> None:
         pass
 
     def __repr__(self) -> str:
@@ -423,9 +423,9 @@ class Compose(Transform):
             return Compose(*self.transforms[item])
         return transform
 
-    def dump(self) -> None:
+    def dump(self, **kwargs) -> None:
         for t in self:
-            t.dump()
+            t.dump(**kwargs)
 
     def reset(self, tensordict: _TensorDict) -> _TensorDict:
         for t in self.transforms:

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -78,10 +78,18 @@ class VideoRecorder(ObservationTransform):
             self.obs.append(observation_trsf.cpu().to(torch.uint8))
         return observation
 
-    def dump(self) -> None:
-        """Writes the video to the self.writer attribute."""
+    def dump(self, suffix: Optional[str] = None) -> None:
+        """Writes the video to the self.writer attribute.
+
+        Args:
+            suffix (str, optional): a suffix for the video to be recorded
+        """
+        if suffix is None:
+            tag = self.tag
+        else:
+            tag = "_".join([self.tag, suffix])
         self.writer.add_video(
-            tag=f"{self.tag}",
+            tag=tag,
             vid_tensor=torch.stack(self.obs, 0).unsqueeze(0),
             global_step=self.iter,
             **self.video_kwargs,
@@ -134,13 +142,18 @@ class TensorDictRecorder(Transform):
             self.td.append(_td)
         return td
 
-    def dump(self) -> None:
+    def dump(self, suffix: Optional[str] = None) -> None:
+        if suffix is None:
+            tag = self.tag
+        else:
+            tag = "_".join([self.tag, suffix])
+
         td = self.td
         if self.skip_reset:
             td = td[1:]
         torch.save(
             torch.stack(td, 0).contiguous(),
-            f"{self.out_file_base}_tensordict.t",
+            f"{tag}_tensordict.t",
         )
         self.iter += 1
         self.count = 0

--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -205,6 +205,7 @@ def make_trainer(
                 record_interval=args.record_interval,
                 exploration_mode="random",
                 suffix="exploration",
+                out_key="r_evaluation_exploration"
             ),
         )
     trainer.register_op("post_steps", UpdateWeights(collector, 1))

--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -195,6 +195,18 @@ def make_trainer(
                 record_interval=args.record_interval,
             ),
         )
+        trainer.register_op(
+            "post_steps_log",
+            Recorder(
+                record_frames=args.record_frames,
+                frame_skip=args.frame_skip,
+                policy_exploration=policy_exploration,
+                recorder=recorder,
+                record_interval=args.record_interval,
+                exploration_mode="random",
+                suffix="exploration",
+            ),
+        )
     trainer.register_op("post_steps", UpdateWeights(collector, 1))
 
     trainer.register_op("pre_steps_log", LogReward())

--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -205,7 +205,7 @@ def make_trainer(
                 record_interval=args.record_interval,
                 exploration_mode="random",
                 suffix="exploration",
-                out_key="r_evaluation_exploration"
+                out_key="r_evaluation_exploration",
             ),
         )
     trainer.register_op("post_steps", UpdateWeights(collector, 1))

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -797,6 +797,7 @@ class Recorder:
             "mode". Set to "random" to enable exploration
         out_key (str, optional): reward key to set to the logger. Default is
             `"reward_evaluation"`.
+        suffix (str, optional): suffix of the video to be recorded.
 
     """
 
@@ -809,6 +810,7 @@ class Recorder:
         recorder: _EnvClass,
         exploration_mode: str = "mode",
         out_key: str = "r_evaluation",
+        suffix: Optional[str] = None,
     ) -> None:
 
         self.policy_exploration = policy_exploration
@@ -819,6 +821,7 @@ class Recorder:
         self.record_interval = record_interval
         self.exploration_mode = exploration_mode
         self.out_key = out_key
+        self.suffix = suffix
 
     @torch.no_grad()
     def __call__(self, batch: _TensorDict) -> Tuple[str, torch.Tensor]:
@@ -839,7 +842,7 @@ class Recorder:
                     self.policy_exploration.train()
                 self.recorder.train()
                 reward = td_record.get("reward").mean() / self.frame_skip
-                self.recorder.transform.dump()
+                self.recorder.transform.dump(suffix=self.suffix)
                 out = self.out_key, reward
         self._count += 1
         return out


### PR DESCRIPTION
Adds another recorder to the default trainer that will record explorative rollouts. This can give an empirical idea of what exploration looks like.