### PR TITLE
Extend transforms in `TransformedEnv` to keep track of specs

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -745,6 +745,19 @@ class TestTransforms:
         for key, item in td.items():
             assert item.is_pinned
 
+    def test_append(self):
+        env = ContinuousActionVecMockEnv()
+        obs_spec = env.observation_spec
+        key = list(obs_spec.keys())[0]
+
+        env = TransformedEnv(env)
+        env.append_transform(CatFrames(N=4, cat_dim=-1, keys=[key]))
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 1
+        obs_spec = env.observation_spec
+        obs_spec = obs_spec[key]
+        assert obs_spec.shape[-1] == 4 * env.env.observation_spec[key].shape[-1]
+
 
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -237,7 +237,7 @@ class TransformedEnv(_EnvClass):
     def __init__(
         self,
         env: _EnvClass,
-        transform: Optional[Transform]=None,
+        transform: Optional[Transform] = None,
         cache_specs: bool = True,
         **kwargs,
     ):
@@ -456,6 +456,9 @@ class Compose(Transform):
                 f"type {type(transform)} instead."
             )
         self.transforms.append(transform)
+
+    def __len__(self):
+        return len(self.transforms)
 
     def __repr__(self) -> str:
         layers_str = ", \n\t".join([str(trsf) for trsf in self.transforms])
@@ -887,11 +890,13 @@ class CatFrames(ObservationTransform):
             _observation_spec = observation_spec
         space = _observation_spec.space
         if isinstance(space, ContinuousBox):
-            space.minimum = torch.cat([space.minimum] * self.N, 0)
-            space.maximum = torch.cat([space.maximum] * self.N, 0)
+            space.minimum = torch.cat([space.minimum] * self.N, self.cat_dim)
+            space.maximum = torch.cat([space.maximum] * self.N, self.cat_dim)
             _observation_spec.shape = space.minimum.shape
         else:
-            _observation_spec.shape = torch.Size([self.N, *_observation_spec.shape])
+            shape = list(_observation_spec.shape)
+            shape[self.cat_dim] = self.N * shape[self.cat_dim]
+            _observation_spec.shape = torch.Size(shape)
         observation_spec = _observation_spec
         return observation_spec
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -346,6 +346,7 @@ class TransformedEnv(_EnvClass):
             )
         if not isinstance(self.transform, Compose):
             self.transform = Compose(self.transform)
+            self.transform.set_parent(self)
         self.transform.append(transform)
 
     def __getattr__(self, attr: str) -> Any:
@@ -456,6 +457,7 @@ class Compose(Transform):
                 f"type {type(transform)} instead."
             )
         self.transforms.append(transform)
+        transform.set_parent(self)
 
     def __len__(self):
         return len(self.transforms)

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -131,24 +131,30 @@ def transformed_env_constructor(
         else:
             env = custom_env_maker()
 
-        transforms = []
+        env = TransformedEnv(env)
+
+        if len(video_tag):
+            env.append_transform(
+                VideoRecorder(
+                    writer=writer,
+                    tag=f"{video_tag}_{env_name}_video",
+                ),
+            )
 
         if args.noops:
-            transforms += [NoopResetEnv(env, args.noops)]
+            env.append_transform(NoopResetEnv(env, args.noops))
         if from_pixels:
-            transforms += [
-                ToTensorImage(),
-                Resize(84, 84),
-                GrayScale(),
-                CatFrames(keys=["next_pixels"]),
-                ObservationNorm(loc=-1.0, scale=2.0, keys=["next_pixels"]),
-            ]
+            env.append_transform(ToTensorImage())
+            env.append_transform(Resize(84, 84))
+            env.append_transform(GrayScale())
+            env.append_transform(CatFrames(keys=["next_pixels"]))
+            env.append_transform(ObservationNorm(loc=-1.0, scale=2.0, keys=["next_pixels"]))
         if norm_rewards:
             reward_scaling = 1.0
         if norm_obs_only:
             reward_scaling = 1.0
         if reward_scaling is not None:
-            transforms.append(RewardScaling(0.0, reward_scaling))
+            env.append_transform(RewardScaling(0.0, reward_scaling))
 
         double_to_float_list = []
         if env_library is DMControlEnv:
@@ -163,18 +169,16 @@ def transformed_env_constructor(
 
             # even if there is a single tensor, it'll be renamed in "next_observation_vector"
             out_key = "next_observation_vector"
-            transforms.append(CatTensors(keys=selected_keys, out_key=out_key))
+            env.append_transform(CatTensors(keys=selected_keys, out_key=out_key))
 
             if not vecnorm:
                 if stats is None:
                     _stats = {"loc": 0.0, "scale": 1.0}
                 else:
                     _stats = stats
-                transforms.append(
-                    ObservationNorm(**_stats, keys=[out_key], standard_normal=True)
-                )
+                env.append_transform(ObservationNorm(**_stats, keys=[out_key], standard_normal=True))
             else:
-                transforms.append(
+                env.append_transform(
                     VecNorm(
                         keys=[out_key, "reward"] if not _norm_obs_only else [out_key],
                         decay=0.9999,
@@ -182,33 +186,17 @@ def transformed_env_constructor(
                 )
 
             double_to_float_list.append(out_key)
-            transforms.append(DoubleToFloat(keys=double_to_float_list))
+            env.append_transform(DoubleToFloat(keys=double_to_float_list))
 
             if hasattr(args, "gSDE") and args.gSDE:
-                transforms.append(
-                    gSDENoise(
-                        action_dim=env.action_spec.shape[-1],
-                    )
-                )
+                env.append_transform(gSDENoise(action_dim=env.action_spec.shape[-1]))
 
         else:
-            transforms.append(DoubleToFloat(keys=double_to_float_list))
+            env.append_transform(DoubleToFloat(keys=double_to_float_list))
             if hasattr(args, "gSDE") and args.gSDE:
                 raise RuntimeError("gSDE not compatible with from_pixels=True")
 
-        if len(video_tag):
-            transforms = [
-                VideoRecorder(
-                    writer=writer,
-                    tag=f"{video_tag}_{env_name}_video",
-                ),
-                *transforms,
-            ]
-        transforms.append(FiniteTensorDictCheck())
-        env = TransformedEnv(
-            env,
-            Compose(*transforms),
-        )
+        env.append_transform(FiniteTensorDictCheck())
         return env
 
     if use_env_creator:

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -14,7 +14,6 @@ from torchrl.envs.env_creator import env_creator, EnvCreator
 from torchrl.envs.transforms import (
     CatFrames,
     CatTensors,
-    Compose,
     DoubleToFloat,
     FiniteTensorDictCheck,
     GrayScale,

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -148,7 +148,9 @@ def transformed_env_constructor(
             env.append_transform(Resize(84, 84))
             env.append_transform(GrayScale())
             env.append_transform(CatFrames(keys=["next_pixels"]))
-            env.append_transform(ObservationNorm(loc=-1.0, scale=2.0, keys=["next_pixels"]))
+            env.append_transform(
+                ObservationNorm(loc=-1.0, scale=2.0, keys=["next_pixels"])
+            )
         if norm_rewards:
             reward_scaling = 1.0
         if norm_obs_only:
@@ -176,7 +178,9 @@ def transformed_env_constructor(
                     _stats = {"loc": 0.0, "scale": 1.0}
                 else:
                     _stats = stats
-                env.append_transform(ObservationNorm(**_stats, keys=[out_key], standard_normal=True))
+                env.append_transform(
+                    ObservationNorm(**_stats, keys=[out_key], standard_normal=True)
+                )
             else:
                 env.append_transform(
                     VecNorm(

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -158,7 +158,7 @@ def transformed_env_constructor(
             reward_scaling = 1.0
             reward_loc = 0.0
         if reward_scaling is not None:
-            transforms.append(RewardScaling(reward_loc, reward_scaling))
+            env.append_transform(RewardScaling(reward_loc, reward_scaling))
 
         double_to_float_list = []
         if env_library is DMControlEnv:
@@ -200,7 +200,14 @@ def transformed_env_constructor(
                 )
 
             if hasattr(args, "gSDE") and args.gSDE:
-                env.append_transform(gSDENoise(action_dim=env.action_spec.shape[-1]))
+                state_dim = env.observation_spec[out_key].shape[-1]
+                env.append_transform(
+                    gSDENoise(
+                        action_dim=env.action_spec.shape[-1],
+                        observation_key=out_key,
+                        state_dim=state_dim,
+                    )
+                )
 
         else:
             env.append_transform(DoubleToFloat(keys=double_to_float_list))


### PR DESCRIPTION
`TransformedEnv` can now be created incrementally by adding transforms one at a time.
This is useful if a transform takes as argument `transform = MyTransform(..., env.observation_spec)` for instance. In that case, incrementing the transforms will ensure that `observation_spec` matches what the transform will see.

Old usage
```python
env = my_env()
transfroms = []
transfroms.append(transform1)
transfroms.append(transform2)
env = TransformedEnv(env, Compose(*transforms))
```

New usage
```python
env = my_env()
env = TransformedEnv(env)
env.append_transform(transform1)
env.append_transform(transform2)
```
