### PR TITLE
Fix GAE error + naming issue

### DIFF
--- a/torchrl/objectives/costs/ppo.py
+++ b/torchrl/objectives/costs/ppo.py
@@ -58,7 +58,7 @@ class PPOLoss(_LossModule):
         actor: ProbabilisticTDModule,
         critic: TDModule,
         advantage_key: str = "advantage",
-        advantage_diff_key: str = "value_target",
+        advantage_diff_key: str = "value_error",
         entropy_bonus: bool = True,
         samples_mc_entropy: int = 1,
         entropy_factor: float = 0.01,

--- a/torchrl/objectives/costs/reinforce.py
+++ b/torchrl/objectives/costs/reinforce.py
@@ -18,7 +18,7 @@ class ReinforceLoss(_LossModule):
         delay_value: bool = False,
         gamma: float = 0.99,
         advantage_key: str = "advantage",
-        advantage_diff_key: str = "value_target",
+        advantage_diff_key: str = "value_error",
         loss_critic_type: str = "smooth_l1",
     ) -> None:
         super().__init__()


### PR DESCRIPTION
Fixes the GAE value loss.
Also renamed the `"value_target"` key to `"value_error"` for more clarity (for both GAE and TD).