### PR TITLE
[WIP] Refactor the probabilistic TDModule class

### DIFF
--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -13,13 +13,13 @@ from torch import nn
 from torchrl.data import NdBoundedTensorSpec
 from torchrl.data.tensordict.tensordict import TensorDict
 from torchrl.envs.transforms.transforms import gSDENoise
-from torchrl.modules import ProbabilisticActor
 from torchrl.modules.distributions import TanhNormal
 from torchrl.modules.distributions.continuous import (
     IndependentNormal,
     NormalParamWrapper,
 )
 from torchrl.modules.models.exploration import gSDEWrapper
+from torchrl.modules.td_module.deprec import ProbabilisticActor_deprecated
 from torchrl.modules.td_module.exploration import (
     _OrnsteinUhlenbeckProcess,
     OrnsteinUhlenbeckProcessWrapper,
@@ -58,7 +58,7 @@ def test_ou_wrapper(device, d_obs=4, d_act=6, batch=32, n_steps=100, seed=0):
     torch.manual_seed(seed)
     module = NormalParamWrapper(nn.Linear(d_obs, 2 * d_act)).to(device)
     action_spec = NdBoundedTensorSpec(-torch.ones(d_act), torch.ones(d_act), (d_act,))
-    policy = ProbabilisticActor(
+    policy = ProbabilisticActor_deprecated(
         spec=action_spec,
         module=module,
         distribution_class=TanhNormal,
@@ -110,7 +110,7 @@ def test_gsde(state_dim, action_dim, gSDE, device, safe, batch=16, bound=0.1):
     spec = NdBoundedTensorSpec(
         -torch.ones(action_dim) * bound, torch.ones(action_dim) * bound, (action_dim,)
     ).to(device)
-    actor = ProbabilisticActor(
+    actor = ProbabilisticActor_deprecated(
         module=wrapper,
         spec=spec,
         in_keys=in_keys,
@@ -127,7 +127,7 @@ def test_gsde(state_dim, action_dim, gSDE, device, safe, batch=16, bound=0.1):
         ],
     )
     if gSDE:
-        gSDENoise(action_dim, state_dim).reset(td)
+        gSDENoise().reset(td)
         assert "_eps_gSDE" in td.keys()
         assert td.get("_eps_gSDE").device == device
     actor(td)

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -13,13 +13,14 @@ from torch import nn
 from torchrl.data import NdBoundedTensorSpec
 from torchrl.data.tensordict.tensordict import TensorDict
 from torchrl.envs.transforms.transforms import gSDENoise
+from torchrl.modules import TDModule
 from torchrl.modules.distributions import TanhNormal
 from torchrl.modules.distributions.continuous import (
     IndependentNormal,
     NormalParamWrapper,
 )
 from torchrl.modules.models.exploration import gSDEWrapper
-from torchrl.modules.td_module.deprec import ProbabilisticActor_deprecated
+from torchrl.modules.td_module.actors import ProbabilisticActor
 from torchrl.modules.td_module.exploration import (
     _OrnsteinUhlenbeckProcess,
     OrnsteinUhlenbeckProcessWrapper,
@@ -56,11 +57,13 @@ def test_ou(device, seed=0):
 @pytest.mark.parametrize("device", get_available_devices())
 def test_ou_wrapper(device, d_obs=4, d_act=6, batch=32, n_steps=100, seed=0):
     torch.manual_seed(seed)
-    module = NormalParamWrapper(nn.Linear(d_obs, 2 * d_act)).to(device)
+    net = NormalParamWrapper(nn.Linear(d_obs, 2 * d_act)).to(device)
+    module = TDModule(net, in_keys=["observation"], out_keys=["loc", "scale"])
     action_spec = NdBoundedTensorSpec(-torch.ones(d_act), torch.ones(d_act), (d_act,))
-    policy = ProbabilisticActor_deprecated(
+    policy = ProbabilisticActor(
         spec=action_spec,
         module=module,
+        dist_param_keys=["loc", "scale"],
         distribution_class=TanhNormal,
         default_interaction_mode="random",
     ).to(device)
@@ -93,27 +96,34 @@ def test_ou_wrapper(device, d_obs=4, d_act=6, batch=32, n_steps=100, seed=0):
 @pytest.mark.parametrize("device", get_available_devices())
 def test_gsde(state_dim, action_dim, gSDE, device, safe, batch=16, bound=0.1):
     torch.manual_seed(0)
+    exploration_mode = "random"
     if gSDE:
         model = torch.nn.LazyLinear(action_dim)
         wrapper = gSDEWrapper(model, action_dim, state_dim).to(device)
-        exploration_mode = "net_output"
+        in_keys = ["observation", "_eps_gSDE"]
+        module = TDModule(
+            wrapper, in_keys=in_keys, out_keys=["loc", "scale", "action", "_eps_gSDE"]
+        ).to(device)
         distribution_class = IndependentNormal
         distribution_kwargs = {}
-        in_keys = ["observation", "_eps_gSDE"]
     else:
+        in_keys = ["observation"]
         model = torch.nn.LazyLinear(action_dim * 2)
-        wrapper = NormalParamWrapper(model).to(device)
-        exploration_mode = "random"
+        wrapper = NormalParamWrapper(model)
+        module = TDModule(wrapper, in_keys=in_keys, out_keys=["loc", "scale"]).to(
+            device
+        )
         distribution_class = TanhNormal
         distribution_kwargs = {"min": -bound, "max": bound}
-        in_keys = ["observation"]
     spec = NdBoundedTensorSpec(
         -torch.ones(action_dim) * bound, torch.ones(action_dim) * bound, (action_dim,)
     ).to(device)
-    actor = ProbabilisticActor_deprecated(
-        module=wrapper,
+
+    actor = ProbabilisticActor(
+        module=module,
         spec=spec,
-        in_keys=in_keys,
+        dist_param_keys=["loc", "scale"],
+        out_key_sample=["action"],
         distribution_class=distribution_class,
         distribution_kwargs=distribution_kwargs,
         default_interaction_mode=exploration_mode,
@@ -136,6 +146,15 @@ def test_gsde(state_dim, action_dim, gSDE, device, safe, batch=16, bound=0.1):
         assert not spec.is_in(td.get("action"))
     elif safe and gSDE:
         assert spec.is_in(td.get("action"))
+
+    if not safe:
+        action1 = module(td).get("action")
+        action2 = actor(td).get("action")
+        if gSDE:
+            torch.testing.assert_allclose(action1, action2)
+        else:
+            with pytest.raises(AssertionError):
+                torch.testing.assert_allclose(action1, action2)
 
 
 if __name__ == "__main__":

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -102,7 +102,7 @@ def test_ddpg_maker(device, from_pixels):
     actor, value = make_ddpg_actor(proof_environment, device=device, args=args)
     td = proof_environment.reset().to(device)
     actor(td)
-    expected_keys = ["done", "action", "net_output"]
+    expected_keys = ["done", "action", "param"]
     if from_pixels:
         expected_keys += ["pixels"]
     else:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -102,7 +102,7 @@ def test_ddpg_maker(device, from_pixels):
     actor, value = make_ddpg_actor(proof_environment, device=device, args=args)
     td = proof_environment.reset().to(device)
     actor(td)
-    expected_keys = ["done", "action"]
+    expected_keys = ["done", "action", "net_output"]
     if from_pixels:
         expected_keys += ["pixels"]
     else:
@@ -157,15 +157,15 @@ def test_ppo_maker(device, from_pixels, shared_mapping, gsde):
     expected_keys = [
         "done",
         "pixels" if len(from_pixels) else "observation_vector",
-        "action_dist_param_0",
-        "action_dist_param_1",
         "action",
-        "action_log_prob",
+        "sample_log_prob",
+        "loc",
+        "scale",
     ]
     if shared_mapping:
         expected_keys += ["hidden"]
     if len(gsde):
-        expected_keys += ["_eps_gSDE", "_action_duplicate", "action_dist_param_2"]
+        expected_keys += ["_eps_gSDE"]
     td = proof_environment.reset().to(device)
     td_clone = td.clone()
     actor(td_clone)
@@ -234,6 +234,8 @@ def test_sac_make(device, gsde, tanh_loc, from_pixels):
         "done",
         "pixels" if len(from_pixels) else "observation_vector",
         "action",
+        "loc",
+        "scale",
     ]
     if len(gsde):
         expected_keys += ["_eps_gSDE"]
@@ -245,7 +247,14 @@ def test_sac_make(device, gsde, tanh_loc, from_pixels):
         raise
 
     qvalue(td_clone)
-    expected_keys = ["done", "observation_vector", "action", "state_action_value"]
+    expected_keys = [
+        "done",
+        "observation_vector",
+        "action",
+        "state_action_value",
+        "loc",
+        "scale",
+    ]
     if len(gsde):
         expected_keys += ["_eps_gSDE"]
 
@@ -299,7 +308,14 @@ def test_redq_make(device, from_pixels, gsde):
     actor, qvalue = model
     td = proof_environment.reset().to(device)
     actor(td)
-    expected_keys = ["done", "observation_vector", "action", "action_log_prob"]
+    expected_keys = [
+        "done",
+        "observation_vector",
+        "action",
+        "sample_log_prob",
+        "loc",
+        "scale",
+    ]
     if len(gsde):
         expected_keys += ["_eps_gSDE"]
     try:
@@ -313,8 +329,10 @@ def test_redq_make(device, from_pixels, gsde):
         "done",
         "observation_vector",
         "action",
-        "action_log_prob",
+        "sample_log_prob",
         "state_action_value",
+        "loc",
+        "scale",
     ]
     if len(gsde):
         expected_keys += ["_eps_gSDE"]

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -16,9 +16,9 @@ from torchrl.modules import (
     ActorValueOperator,
     TDModule,
     ValueOperator,
+    ProbabilisticActor,
 )
 from torchrl.modules.models import NoisyLinear, MLP, NoisyLazyLinear
-from torchrl.modules.td_module.deprec import ProbabilisticActor_deprecated
 
 
 @pytest.mark.parametrize("in_features", [3, 10, None])
@@ -130,8 +130,9 @@ def test_actorcritic(device):
     common_module = TDModule(
         spec=None, module=nn.Linear(3, 4), in_keys=["obs"], out_keys=["hidden"]
     ).to(device)
-    policy_operator = ProbabilisticActor_deprecated(
-        spec=None, module=nn.Linear(4, 5), in_keys=["hidden"], return_log_prob=True
+    module = TDModule(nn.Linear(4, 5), in_keys=["hidden"], out_keys=["param"])
+    policy_operator = ProbabilisticActor(
+        spec=None, module=module, dist_param_keys=["param"], return_log_prob=True
     ).to(device)
     value_operator = ValueOperator(nn.Linear(4, 1), in_keys=["hidden"]).to(device)
     op = ActorValueOperator(

--- a/test/test_modules.py
+++ b/test/test_modules.py
@@ -16,9 +16,9 @@ from torchrl.modules import (
     ActorValueOperator,
     TDModule,
     ValueOperator,
-    ProbabilisticActor,
 )
 from torchrl.modules.models import NoisyLinear, MLP, NoisyLazyLinear
+from torchrl.modules.td_module.deprec import ProbabilisticActor_deprecated
 
 
 @pytest.mark.parametrize("in_features", [3, 10, None])
@@ -130,7 +130,7 @@ def test_actorcritic(device):
     common_module = TDModule(
         spec=None, module=nn.Linear(3, 4), in_keys=["obs"], out_keys=["hidden"]
     ).to(device)
-    policy_operator = ProbabilisticActor(
+    policy_operator = ProbabilisticActor_deprecated(
         spec=None, module=nn.Linear(4, 5), in_keys=["hidden"], return_log_prob=True
     ).to(device)
     value_operator = ValueOperator(nn.Linear(4, 1), in_keys=["hidden"]).to(device)
@@ -152,7 +152,7 @@ def test_actorcritic(device):
     td_value = value_op(td)
     torch.testing.assert_allclose(td_total.get("action"), td_policy.get("action"))
     torch.testing.assert_allclose(
-        td_total.get("action_log_prob"), td_policy.get("action_log_prob")
+        td_total.get("sample_log_prob"), td_policy.get("sample_log_prob")
     )
     torch.testing.assert_allclose(
         td_total.get("state_value"), td_value.get("state_value")

--- a/test/test_tdmodules.py
+++ b/test/test_tdmodules.py
@@ -13,6 +13,7 @@ from torchrl.data import TensorDict
 from torchrl.data.tensor_specs import (
     NdUnboundedContinuousTensorSpec,
     NdBoundedTensorSpec,
+    CompositeSpec,
 )
 from torchrl.envs.utils import set_exploration_mode
 from torchrl.modules import (
@@ -114,7 +115,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=net,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -124,7 +125,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=net,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -225,7 +226,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -235,7 +236,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -283,7 +284,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -293,7 +294,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -394,7 +395,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -404,7 +405,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -452,7 +453,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -462,7 +463,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -588,7 +589,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -598,7 +599,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -671,7 +672,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=spec,
+                    spec=CompositeSpec(out=spec, loc=None, scale=None),
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -681,7 +682,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -850,7 +851,7 @@ class TestTDSequence:
                 safe=False,
             )
             tdmodule2 = ProbabilisticTensorDictModule(
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 module=net2,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
@@ -1000,7 +1001,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 fnet2,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -1168,7 +1169,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 fnet2,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -1239,7 +1240,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 net2,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -1399,7 +1400,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 fnet2,
-                spec=spec,
+                spec=CompositeSpec(out=spec, loc=None, scale=None),
                 out_key_sample=["out"],
                 dist_param_keys=["loc", "scale"],
                 safe=safe,

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -216,7 +216,7 @@ class SyncDataCollector(_DataCollector):
             at each iteration.
             default = False
         exploration_mode (str, optional): interaction mode to be used when collecting data. Must be one of "random",
-            "mode", "mean" or "net_output".
+            "mode", "mean" or "param".
             default = "random"
         init_with_lag (bool, optional): if True, the first trajectory will be truncated earlier at a random step.
             This is helpful to desynchronize the environments, such that steps do no match in all collected rollouts.
@@ -387,7 +387,7 @@ class SyncDataCollector(_DataCollector):
         else:
             if td.device == torch.device("cpu") and self.pin_memory:
                 td.pin_memory()
-            self._td_policy.update(td, inplace=True)
+            self._td_policy.update(td, inplace=False)
         return self._td_policy
 
     def _cast_to_env(
@@ -398,10 +398,10 @@ class SyncDataCollector(_DataCollector):
             if self._td_env is None:
                 self._td_env = td.to(env_device)
             else:
-                self._td_env.update(td, inplace=True)
+                self._td_env.update(td, inplace=False)
             return self._td_env
         else:
-            return dest.update(td, inplace=True)
+            return dest.update(td, inplace=False)
 
     def _reset_if_necessary(self) -> None:
         done = self._tensordict.get("done")
@@ -618,7 +618,7 @@ class _MultiDataCollector(_DataCollector):
             This is helpful to desynchronize the environments, such that steps do no match in all collected rollouts.
             default = True
        exploration_mode (str, optional): interaction mode to be used when collecting data. Must be one of "random",
-            "mode", "mean" or "net_output".
+            "mode", "mean" or "param".
             default = "random"
 
     """

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -19,7 +19,7 @@ from torch import multiprocessing as mp
 from torch.utils.data import IterableDataset
 
 from torchrl.envs.utils import set_exploration_mode, step_tensordict
-from torchrl.modules import ProbabilisticTDModule
+from ..modules.td_module import ProbabilisticTensorDictModule
 from .utils import split_trajectories
 
 __all__ = [
@@ -83,10 +83,12 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
         ] = None,
         create_env_kwargs: Optional[dict] = None,
         policy: Optional[
-            Union[ProbabilisticTDModule, Callable[[_TensorDict], _TensorDict]]
+            Union[ProbabilisticTensorDictModule, Callable[[_TensorDict], _TensorDict]]
         ] = None,
         device: Optional[DEVICE_TYPING] = None,
-    ) -> Tuple[ProbabilisticTDModule, torch.device, Union[None, Callable[[], dict]]]:
+    ) -> Tuple[
+        ProbabilisticTensorDictModule, torch.device, Union[None, Callable[[], dict]]
+    ]:
         """From a policy and a device, assigns the self.device attribute to
         the desired device and maps the policy onto it or (if the device is
         ommitted) assigns the self.device attribute to the policy device.
@@ -95,7 +97,7 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
             create_env_fn (Callable or list of callables): an env creator
                 function (or a list of creators)
             create_env_kwargs (dictionary): kwargs for the env creator
-            policy (ProbabilisticTDModule, optional): a policy to be used
+            policy (ProbabilisticTensorDictModule, optional): a policy to be used
             device (int, str or torch.device, optional): device where to place
                 the policy
 
@@ -231,7 +233,7 @@ class SyncDataCollector(_DataCollector):
             _EnvClass, "EnvCreator", Sequence[Callable[[], _EnvClass]]
         ],
         policy: Optional[
-            Union[ProbabilisticTDModule, Callable[[_TensorDict], _TensorDict]]
+            Union[ProbabilisticTensorDictModule, Callable[[_TensorDict], _TensorDict]]
         ] = None,
         total_frames: Optional[int] = -1,
         create_env_kwargs: Optional[dict] = None,
@@ -574,7 +576,8 @@ class _MultiDataCollector(_DataCollector):
 
     Args:
         create_env_fn (list of Callabled): list of Callables, each returning an instance of _EnvClass
-        policy (Callable, optional): Instance of ProbabilisticTDModule class. Must accept _TensorDict object as input.
+        policy (Callable, optional): Instance of ProbabilisticTensorDictModule class.
+            Must accept _TensorDict object as input.
         total_frames (int): lower bound of the total number of frames returned by the collector. In parallel settings,
             the actual number of frames may well be greater than this as the closing signals are sent to the
             workers only once the total number of frames has been collected on the server.
@@ -624,7 +627,7 @@ class _MultiDataCollector(_DataCollector):
         self,
         create_env_fn: Sequence[Callable[[], _EnvClass]],
         policy: Optional[
-            Union[ProbabilisticTDModule, Callable[[_TensorDict], _TensorDict]]
+            Union[ProbabilisticTensorDictModule, Callable[[_TensorDict], _TensorDict]]
         ] = None,
         total_frames: Optional[int] = -1,
         create_env_kwargs: Optional[Sequence[dict]] = None,
@@ -1091,7 +1094,7 @@ class aSyncDataCollector(MultiaSyncDataCollector):
 
     Args:
         create_env_fn (Callabled): Callable returning an instance of _EnvClass
-        policy (Callable, optional): Instance of ProbabilisticTDModule class.
+        policy (Callable, optional): Instance of ProbabilisticTensorDictModule class.
             Must accept _TensorDict object as input.
         total_frames (int): lower bound of the total number of frames returned
             by the collector. In parallel settings, the actual number of
@@ -1145,7 +1148,7 @@ class aSyncDataCollector(MultiaSyncDataCollector):
         self,
         create_env_fn: Callable[[], _EnvClass],
         policy: Optional[
-            Union[ProbabilisticTDModule, Callable[[_TensorDict], _TensorDict]]
+            Union[ProbabilisticTensorDictModule, Callable[[_TensorDict], _TensorDict]]
         ] = None,
         total_frames: Optional[int] = -1,
         create_env_kwargs: Optional[dict] = None,

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -866,11 +866,17 @@ dtype=torch.float32)},
         return f"CompositeSpec(\n{sub_str})"
 
     def type_check(
-        self, value: _TensorDict, selected_keys: Optional[Sequence[str]] = None
+        self,
+        value: Union[torch.Tensor, _TensorDict],
+        selected_keys: Union[str, Optional[Sequence[str]]] = None,
     ):
+        if isinstance(value, torch.Tensor) and isinstance(selected_keys, str):
+            value = {selected_keys: value}
+            selected_keys = [selected_keys]
+
         for _key in self:
             if selected_keys is None or _key in selected_keys:
-                self._specs[_key].type_check(value[key], _key)
+                self._specs[_key].type_check(value[_key], _key)
 
     def is_in(self, val: Union[dict, _TensorDict]) -> bool:
         return all(
@@ -904,3 +910,6 @@ dtype=torch.float32)},
 
     def values(self) -> ValuesView:
         return self._specs.values()
+
+    def __len__(self):
+        return len(self.keys())

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -253,7 +253,9 @@ class _EnvClass:
                 f"env._reset returned an object of type {type(tensordict_reset)} but a TensorDict was expected."
             )
 
-        self.current_tensordict = step_tensordict(tensordict_reset, keep_other=True)
+        self.current_tensordict = step_tensordict(
+            tensordict_reset, exclude_reward_done_action=False
+        )
         self.is_done = tensordict_reset.get(
             "done",
             torch.zeros(self.batch_size, dtype=torch.bool, device=self.device),

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1337,28 +1337,16 @@ class gSDENoise(Transform):
 
     def __init__(
         self,
-        action_dim: int,
-        state_dim: Optional[int] = None,
-        observation_key="next_observation_vector",
     ) -> None:
         super().__init__(keys=[])
-        self.action_dim = action_dim
-        self.state_dim = state_dim
-        self.observation_key = observation_key
 
     def reset(self, tensordict: _TensorDict) -> _TensorDict:
         tensordict = super().reset(tensordict=tensordict)
-        if self.state_dim is None:
-            raise RuntimeError("state_dim must be provided to gSDENoise transform")
-        else:
-            state_dim = self.state_dim
-
         tensordict.set(
             "_eps_gSDE",
-            torch.randn(
+            torch.zeros(
                 *tensordict.batch_size,
-                self.action_dim,
-                state_dim,
+                1,
                 device=tensordict.device,
             ),
         )

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -64,7 +64,8 @@ def step_tensordict(
     keys = [key for key in tensordict.keys() if key.startswith("next_")]
     new_keys = [key[5:] for key in keys]
     if keep_other:
-        other_keys = [key for key in tensordict.keys() if key not in new_keys]
+        prohibited = set(keys).union(new_keys)
+        other_keys = [key for key in tensordict.keys() if key not in prohibited]
     select_tensordict = tensordict.select(*other_keys, *keys).clone()
     for new_key, key in zip(new_keys, keys):
         select_tensordict.rename_key(key, new_key, safe=True)

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -21,7 +21,8 @@ class classproperty(property):
 def step_tensordict(
     tensordict: _TensorDict,
     next_tensordict: _TensorDict = None,
-    keep_other: bool = False,
+    keep_other: bool = True,
+    exclude_reward_done_action: bool = True,
 ) -> _TensorDict:
     """
     Given a tensordict retrieved after a step, returns another tensordict with all the 'next_' prefixes are removed,
@@ -32,7 +33,10 @@ def step_tensordict(
         tensordict (_TensorDict): tensordict with keys to be renamed
         next_tensordict (_TensorDict, optional): destination tensordict
         keep_other (bool, optional): if True, all keys that do not start with `'next_'` will be kept.
-            Default is False.
+            Default is True.
+        exclude_reward_done_action (bool, optional): if True, `"reward"` and `"done"` keys will be discarded
+            from the resulting tensordict ast they are considered to be time-sensitive.
+            Default is True.
 
     Returns:
          A new tensordict (or next_tensordict) with the "next_*" keys renamed without the "next_" prefix.
@@ -54,6 +58,9 @@ def step_tensordict(
 
     """
     other_keys = []
+    if exclude_reward_done_action:
+        # we exclude those keys to make sure we aren't reporting time-specific values at the next step.
+        tensordict = tensordict.exclude("reward", "done", "action")
     keys = [key for key in tensordict.keys() if key.startswith("next_")]
     new_keys = [key[5:] for key in keys]
     if keep_other:

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -452,7 +452,7 @@ class TanhDelta(D.TransformedDistribution):
     Implements a Tanh transformed Delta distribution.
 
     Args:
-        net_output (torch.Tensor): parameter of the delta distribution;
+        param (torch.Tensor): parameter of the delta distribution;
                 min (torch.Tensor or number): minimum value of the distribution. Default is -1.0;
         min (torch.Tensor or number, optional): minimum value of the distribution. Default is 1.0;
         max (torch.Tensor or number, optional): maximum value of the distribution. Default is 1.0;
@@ -473,7 +473,7 @@ class TanhDelta(D.TransformedDistribution):
 
     def __init__(
         self,
-        net_output: torch.Tensor,
+        param: torch.Tensor,
         min: Union[torch.Tensor, float] = -1.0,
         max: Union[torch.Tensor, float] = 1.0,
         event_dims: int = 1,
@@ -492,9 +492,9 @@ class TanhDelta(D.TransformedDistribution):
             if not all(max > min):
                 raise ValueError(minmax_msg)
 
-        self.min = _cast_device(min, net_output.device)
-        self.max = _cast_device(max, net_output.device)
-        loc = self.update(net_output)
+        self.min = _cast_device(min, param.device)
+        self.max = _cast_device(max, param.device)
+        loc = self.update(param)
 
         t = SafeTanhTransform()
         non_trivial_min = (isinstance(min, torch.Tensor) and (min != -1.0).any()) or (
@@ -512,8 +512,8 @@ class TanhDelta(D.TransformedDistribution):
                     ),
                 ]
             )
-        event_shape = net_output.shape[-event_dims:]
-        batch_shape = net_output.shape[:-event_dims]
+        event_shape = param.shape[-event_dims:]
+        batch_shape = param.shape[:-event_dims]
         base = Delta(
             loc,
             atol=atol,

--- a/torchrl/modules/td_module/__init__.py
+++ b/torchrl/modules/td_module/__init__.py
@@ -6,3 +6,5 @@
 from .actors import *
 from .common import *
 from .exploration import *
+from .sequence import *
+from .probabilistic import *

--- a/torchrl/modules/td_module/actors.py
+++ b/torchrl/modules/td_module/actors.py
@@ -27,14 +27,15 @@ __all__ = [
     "DistributionalQValueActor",
 ]
 
-from torchrl.data import UnboundedContinuousTensorSpec
+from torchrl.data import UnboundedContinuousTensorSpec, CompositeSpec, TensorSpec
 
 
 class Actor(TDModule):
     """General class for deterministic actors in RL.
 
-    The Actor class comes with default values for the in_keys and out_keys
-    arguments (["observation"] and ["action"], respectively).
+    The Actor class comes with default values for the out_keys (["action"])
+    and if the spec is provided but not as a CompositeSpec object, it will be
+    automatically translated into `spec = CompositeSpec(action=spec)`
 
     Examples:
         >>> from torchrl.data import TensorDict,
@@ -58,17 +59,25 @@ class Actor(TDModule):
         *args,
         in_keys: Optional[Sequence[str]] = None,
         out_keys: Optional[Sequence[str]] = None,
+        spec: Optional[TensorSpec] = None,
         **kwargs,
     ):
         if in_keys is None:
             in_keys = ["observation"]
         if out_keys is None:
             out_keys = ["action"]
+        if (
+            "action" in out_keys
+            and spec is not None
+            and not isinstance(spec, CompositeSpec)
+        ):
+            spec = CompositeSpec(action=spec)
 
         super().__init__(
             *args,
             in_keys=in_keys,
             out_keys=out_keys,
+            spec=spec,
             **kwargs,
         )
 
@@ -76,8 +85,9 @@ class Actor(TDModule):
 class ProbabilisticActor(ProbabilisticTensorDictModule):
     """
     General class for probabilistic actors in RL.
-    The Actor class comes with default values for the in_keys and out_keys
-    arguments (["observation"] and ["action"], respectively).
+    The Actor class comes with default values for the out_keys (["action"])
+    and if the spec is provided but not as a CompositeSpec object, it will be
+    automatically translated into `spec = CompositeSpec(action=spec)`
 
     Examples:
         >>> from torchrl.data import TensorDict, NdBoundedTensorSpec
@@ -115,15 +125,23 @@ class ProbabilisticActor(ProbabilisticTensorDictModule):
         module: TDModule,
         dist_param_keys: Union[str, Sequence[str]],
         out_key_sample: Optional[Sequence[str]] = None,
+        spec: Optional[TensorSpec] = None,
         **kwargs,
     ):
         if out_key_sample is None:
             out_key_sample = ["action"]
+        if (
+            "action" in out_key_sample
+            and spec is not None
+            and not isinstance(spec, CompositeSpec)
+        ):
+            spec = CompositeSpec(action=spec)
 
         super().__init__(
             module=module,
             dist_param_keys=dist_param_keys,
             out_key_sample=out_key_sample,
+            spec=spec,
             **kwargs,
         )
 

--- a/torchrl/modules/td_module/actors.py
+++ b/torchrl/modules/td_module/actors.py
@@ -20,6 +20,7 @@ __all__ = [
     "Actor",
     "ActorValueOperator",
     "ValueOperator",
+    "ProbabilisticActor",
     "QValueActor",
     "ActorCriticOperator",
     "ActorCriticWrapper",

--- a/torchrl/modules/td_module/common.py
+++ b/torchrl/modules/td_module/common.py
@@ -5,17 +5,14 @@
 
 from __future__ import annotations
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from textwrap import indent
 from typing import (
     Any,
-    Callable,
     Iterable,
     List,
     Optional,
     Sequence,
-    Tuple,
-    Type,
     Union,
 )
 
@@ -23,22 +20,16 @@ import functorch
 import torch
 from functorch import FunctionalModule, FunctionalModuleWithBuffers, vmap
 from functorch._src.make_functional import _swap_state
-from torch import distributions as d, nn, Tensor
+from torch import nn, Tensor
 
 from torchrl.data import (
-    CompositeSpec,
     DEVICE_TYPING,
     TensorSpec,
-    UnboundedContinuousTensorSpec,
 )
 from torchrl.data.tensordict.tensordict import _TensorDict, TensorDict
-from torchrl.envs.utils import exploration_mode
-from torchrl.modules.distributions import Delta, distributions_maps
 
 __all__ = [
     "TDModule",
-    "ProbabilisticTDModule",
-    "TDSequence",
     "TDModuleWrapper",
 ]
 
@@ -65,12 +56,12 @@ class TDModule(nn.Module):
         module (nn.Module): a nn.Module used to map the input to the output parameter space. Can be a functional
             module (FunctionalModule or FunctionalModuleWithBuffers), in which case the `forward` method will expect
             the params (and possibly) buffers keyword arguments.
-        spec (TensorSpec): specs of the output tensor. If the module outputs multiple output tensors,
-            spec characterize the space of the first output tensor.
         in_keys (iterable of str): keys to be read from input tensordict and passed to the module. If it
             contains more than one element, the values will be passed in the order given by the in_keys iterable.
         out_keys (iterable of str): keys to be written to the input tensordict. The length of out_keys must match the
             number of tensors returned by the embedded module.
+        spec (TensorSpec): specs of the output tensor. If the module outputs multiple output tensors,
+            spec characterize the space of the first output tensor.
         safe (bool): if True, the value of the output is checked against the input spec. Out-of-domain sampling can
             occur because of exploration policies or numerical under/overflow issues.
             If this value is out of bounds, it is projected back onto the desired space using the `TensorSpec.project`
@@ -143,9 +134,9 @@ class TDModule(nn.Module):
         module: Union[
             FunctionalModule, FunctionalModuleWithBuffers, TDModule, nn.Module
         ],
-        spec: Optional[TensorSpec],
         in_keys: Iterable[str],
         out_keys: Iterable[str],
+        spec: Optional[TensorSpec] = None,
         safe: bool = False,
     ):
 
@@ -159,6 +150,8 @@ class TDModule(nn.Module):
         self.in_keys = in_keys
 
         self._spec = spec
+        if spec is not None and not isinstance(spec, TensorSpec):
+            raise TypeError("spec must be a TensorSpec subclass")
         self.safe = safe
         if safe:
             if spec is None:
@@ -242,7 +235,7 @@ class TDModule(nn.Module):
     def _call_module(
         self, tensors: Sequence[Tensor], **kwargs
     ) -> Union[Tensor, Sequence[Tensor]]:
-        err_msg = "Did not find the {0} keyword argument to be used with the functional module."
+        err_msg = "Did not find the {0} keyword argument to be used with the functional module. Check it was passed to the TDModule method."
         if isinstance(self.module, (FunctionalModule, FunctionalModuleWithBuffers)):
             _vmap = self._make_vmap(kwargs, len(tensors))
             if _vmap:
@@ -407,634 +400,6 @@ class TDModule(nn.Module):
             break
 
         return self_copy, (params, buffers)
-
-
-class ProbabilisticTDModule(TDModule):
-    """
-    A probabilistic TD Module.
-    ProbabilisticTDModule is a special case of a TDModule where the output is sampled given some rule, specified by
-    the input `default_interaction_mode` argument and the `exploration_mode()` global function.
-
-    A ProbabilisticTDModule instance has two main features:
-    - It reads and writes TensorDict objects
-    - It uses a real mapping R^n -> R^m to create a distribution in R^d from which values can be sampled or computed.
-    When the __call__ / forward method is called, a distribution is created, and a value computed (using the 'mean',
-    'mode', 'median' attribute or the 'rsample', 'sample' method).
-
-    By default, ProbabilisticTDModule distribution class is a Delta distribution, making ProbabilisticTDModule a
-    simple wrapper around a deterministic mapping function (i.e. it can be used interchangeably with its parent
-    TDModule).
-
-    Args:
-        module (nn.Module): a nn.Module used to map the input to the output parameter space. Can be a functional
-            module (FunctionalModule or FunctionalModuleWithBuffers), in which case the `forward` method will expect
-            the params (and possibly) buffers keyword arguments.
-        spec (TensorSpec): specs of the first output tensor. Used when calling td_module.random() to generate random
-            values in the target space.
-        in_keys (iterable of str): keys to be read from input tensordict and passed to the module. If it
-            contains more than one element, the values will be passed in the order given by the in_keys iterable.
-        out_keys (iterable of str): keys to be written to the input tensordict. The length of out_keys must match the
-            number of tensors returned by the distribution sampling method plus the extra tensors returned by the
-            module.
-        distribution_class (Type, optional): a torch.distributions.Distribution class to be used for sampling.
-            Default is Delta.
-        distribution_kwargs (dict, optional): kwargs to be passed to the distribution.
-        default_interaction_mode (str, optional): default method to be used to retrieve the output value. Should be one of:
-            'mode', 'median', 'mean' or 'random' (in which case the value is sampled randomly from the distribution).
-            Default is 'mode'.
-            Note: When a sample is drawn, the `ProbabilisticTDModule` instance will fist look for the interaction mode
-            dictated by the `exploration_mode()` global function. If this returns `None` (its default value),
-            then the `default_interaction_mode` of the `ProbabilisticTDModule` instance will be used.
-            Note that DataCollector instances will use `set_exploration_mode` to `"random"` by default.
-        return_log_prob (bool, optional): if True, the log-probability of the distribution sample will be written in the
-            tensordict with the key `f'{in_keys[0]}_log_prob'`. Default is `False`.
-        safe (bool, optional): if True, the value of the sample is checked against the input spec. Out-of-domain sampling can
-            occur because of exploration policies or numerical under/overflow issues. As for the `spec` argument,
-            this check will only occur for the distribution sample, but not the other tensors returned by the input
-            module. If the sample is out of bounds, it is projected back onto the desired space using the
-            `TensorSpec.project`
-            method.
-            Default is `False`.
-        save_dist_params (bool, optional): if True, the parameters of the distribution (i.e. the output of the module)
-            will be written to the tensordict along with the sample. Those parameters can be used to
-            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
-            used to sample the action and the updated distribution in PPO).
-            Default is `False`.
-        cache_dist (bool, optional): if True, the parameters of the distribution (i.e. the output of the module)
-            will be written to the tensordict along with the sample. Those parameters can be used to
-            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
-            used to sample the action and the updated distribution in PPO).
-            Default is `False`.
-
-    Examples:
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import ProbabilisticTDModule, TanhNormal
-        >>> import functorch, torch
-        >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
-        >>> spec = NdUnboundedContinuousTensorSpec(4)
-        >>> module = torch.nn.GRUCell(4, 8)
-        >>> module_func, params, buffers = functorch.make_functional_with_buffers(module)
-        >>> td_module = ProbabilisticTDModule(
-        ...    module=module_func,
-        ...    spec=spec,
-        ...    in_keys=["input"],
-        ...    out_keys=["output"],
-        ...    distribution_class=TanhNormal,
-        ...    return_log_prob=True,
-        ...    )
-        >>> _ = td_module(td, params=params, buffers=buffers)
-        >>> print(td)
-        TensorDict(
-            fields={
-                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
-                output: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                output_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
-            batch_size=torch.Size([3]),
-            device=cpu,
-            is_shared=False)
-
-        >>> # In the vmap case, the tensordict is again expended to match the batch:
-        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
-        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
-        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
-        >>> print(td_vmap)
-        TensorDict(
-            fields={
-                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
-                output: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                output_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
-            batch_size=torch.Size([3]),
-            device=cpu,
-            is_shared=False)
-
-    """
-
-    def __init__(
-        self,
-        module: Union[Callable[[Tensor], Tensor], nn.Module],
-        spec: TensorSpec,
-        in_keys: Sequence[str],
-        out_keys: Sequence[str],
-        distribution_class: Type = Delta,
-        distribution_kwargs: Optional[dict] = None,
-        default_interaction_mode: str = "mode",
-        _n_empirical_est: int = 1000,
-        return_log_prob: bool = False,
-        safe: bool = False,
-        save_dist_params: bool = False,
-        cache_dist: bool = False,
-    ):
-
-        super().__init__(
-            spec=spec,
-            module=module,
-            out_keys=out_keys,
-            in_keys=in_keys,
-            safe=safe,
-        )
-
-        self.save_dist_params = save_dist_params
-        self._n_empirical_est = _n_empirical_est
-        self.cache_dist = cache_dist if hasattr(distribution_class, "update") else False
-        self._dist = None
-
-        if isinstance(distribution_class, str):
-            distribution_class = distributions_maps.get(distribution_class.lower())
-        self.distribution_class = distribution_class
-        self.distribution_kwargs = (
-            distribution_kwargs if distribution_kwargs is not None else dict()
-        )
-        self.return_log_prob = return_log_prob
-
-        self.default_interaction_mode = default_interaction_mode
-        self.interact = False
-
-    def get_dist(
-        self,
-        tensordict: _TensorDict,
-        **kwargs,
-    ) -> Tuple[torch.distributions.Distribution, ...]:
-        """Calls the module using the tensors retrieved from the 'in_keys' attribute and returns a distribution
-        using its output.
-
-        Args:
-            tensordict (_TensorDict): tensordict with the input values for the creation of the distribution.
-
-        Returns:
-            a distribution along with other tensors returned by the module.
-
-        """
-        tensors = [tensordict.get(key, None) for key in self.in_keys]
-        out_tensors = self._call_module(tensors, **kwargs)
-        if isinstance(out_tensors, Tensor):
-            out_tensors = (out_tensors,)
-        if self.save_dist_params:
-            for i, _tensor in enumerate(out_tensors):
-                tensordict.set(f"{self.out_keys[0]}_dist_param_{i}", _tensor)
-        dist, num_params = self.build_dist_from_params(out_tensors)
-        tensors = out_tensors[num_params:]
-
-        return (dist, *tensors)
-
-    def build_dist_from_params(
-        self, params: Tuple[Tensor, ...]
-    ) -> Tuple[d.Distribution, int]:
-        """Given a tuple of temsors, returns a distribution object and the number of parameters used for it.
-
-        Args:
-            params (Tuple[Tensor, ...]): tensors to be used for the distribution construction.
-
-        Returns:
-            a distribution object and the number of parameters used for its construction.
-
-        """
-        num_params = (
-            getattr(self.distribution_class, "num_params")
-            if hasattr(self.distribution_class, "num_params")
-            else 1
-        )
-        if self.cache_dist and self._dist is not None:
-            self._dist.update(*params[:num_params])
-            dist = self._dist
-        else:
-            dist = self.distribution_class(
-                *params[:num_params], **self.distribution_kwargs
-            )
-            if self.cache_dist:
-                self._dist = dist
-        return dist, num_params
-
-    def forward(
-        self,
-        tensordict: _TensorDict,
-        tensordict_out: Optional[_TensorDict] = None,
-        **kwargs,
-    ) -> _TensorDict:
-
-        dist, *tensors = self.get_dist(tensordict, **kwargs)
-        out_tensor = self._dist_sample(
-            dist, *tensors, interaction_mode=exploration_mode()
-        )
-        tensordict_out = self._write_to_tensordict(
-            tensordict,
-            [out_tensor] + list(tensors),
-            tensordict_out,
-            vmap=kwargs.get("vmap", 0),
-        )
-        if self.return_log_prob:
-            log_prob = dist.log_prob(out_tensor)
-            tensordict_out.set("_".join([self.out_keys[0], "log_prob"]), log_prob)
-        return tensordict_out
-
-    def log_prob(self, tensordict: _TensorDict, **kwargs) -> _TensorDict:
-        """
-        Samples/computes an action using the module and writes this value onto the input tensordict along
-        with its log-probability.
-
-        Args:
-            tensordict (_TensorDict): tensordict containing the in_keys specified in the initializer.
-
-        Returns:
-            the same tensordict with the out_keys values added/updated as well as a
-                f"{out_keys[0]}_log_prob" key containing the log-probability of the first output.
-
-        """
-        dist, *_ = self.get_dist(tensordict, **kwargs)
-        lp = dist.log_prob(tensordict.get(self.out_keys[0]))
-        tensordict.set(self.out_keys[0] + "_log_prob", lp)
-        return tensordict
-
-    def _dist_sample(
-        self,
-        dist: d.Distribution,
-        *tensors: Tensor,
-        interaction_mode: bool = None,
-        eps: float = None,
-    ) -> Tensor:
-        if interaction_mode is None:
-            interaction_mode = self.default_interaction_mode
-        if not isinstance(dist, d.Distribution):
-            raise TypeError(f"type {type(dist)} not recognised by _dist_sample")
-
-        if interaction_mode == "mode":
-            if hasattr(dist, "mode"):
-                return dist.mode
-            else:
-                raise NotImplementedError(
-                    f"method {type(dist)}.mode is not implemented"
-                )
-
-        elif interaction_mode == "median":
-            if hasattr(dist, "median"):
-                return dist.median
-            else:
-                raise NotImplementedError(
-                    f"method {type(dist)}.median is not implemented"
-                )
-
-        elif interaction_mode == "mean":
-            try:
-                return dist.mean
-            except AttributeError:
-                if dist.has_rsample:
-                    return dist.rsample((self._n_empirical_est,)).mean(0)
-                else:
-                    return dist.sample((self._n_empirical_est,)).mean(0)
-
-        elif interaction_mode == "random":
-            if dist.has_rsample:
-                return dist.rsample()
-            else:
-                return dist.sample()
-        elif interaction_mode == "net_output":
-            if len(tensors) > 1:
-                raise RuntimeError(
-                    "Multiple values passed to _dist_sample when trying to return a single action "
-                    "tensor."
-                )
-            return tensors[0]
-        else:
-            raise NotImplementedError(f"unknown interaction_mode {interaction_mode}")
-
-    @property
-    def device(self):
-        for p in self.parameters():
-            return p.device
-        return torch.device("cpu")
-
-    def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> ProbabilisticTDModule:
-        if self.spec is not None:
-            self.spec = self.spec.to(dest)
-        out = super().to(dest)
-        return out
-
-    def __deepcopy__(self, memodict={}):
-        self._dist = None
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memodict[id(self)] = result
-        for k, v in self.__dict__.items():
-            setattr(result, k, deepcopy(v, memodict))
-        return result
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(module={self.module}, distribution_class={self.distribution_class}, device={self.device})"
-
-
-class TDSequence(TDModule):
-    """
-    A sequence of TDModules.
-    Similarly to `nn.Sequence` which passes a tensor through a chain of mappings that read and write a single tensor
-    each, this module will read and write over a tensordict by querying each of the input modules.
-    When calling a `TDSequence` instance with a functional module, it is expected that the parameter lists (and
-    buffers) will be concatenated in a single list.
-
-    Args:
-         modules (iterable of TDModules): ordered sequence of TDModule instances to be run sequentially.
-
-    TDSequence supportse functional, modular and vmap coding:
-    Examples:
-        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
-        >>> from torchrl.modules import ProbabilisticTDModule, TanhNormal, TDSequence
-        >>> import torch, functorch
-        >>> td = TensorDict({"input": torch.randn(3, 4)}, [3,])
-        >>> spec1 = NdUnboundedContinuousTensorSpec(4)
-        >>> module1 = torch.nn.Linear(4, 8)
-        >>> fmodule1, params1, buffers1 = functorch.make_functional_with_buffers(module1)
-        >>> td_module1 = ProbabilisticTDModule(
-        ...    module=fmodule1,
-        ...    spec=spec1,
-        ...    in_keys=["input"],
-        ...    out_keys=["hidden"],
-        ...    distribution_class=TanhNormal,
-        ...    return_log_prob=True,
-        ...    )
-        >>> spec2 = NdUnboundedContinuousTensorSpec(8)
-        >>> module2 = torch.nn.Linear(4, 8)
-        >>> fmodule2, params2, buffers2 = functorch.make_functional_with_buffers(module2)
-        >>> td_module2 = TDModule(
-        ...    module=fmodule2,
-        ...    spec=spec2,
-        ...    in_keys=["hidden"],
-        ...    out_keys=["output"],
-        ...    )
-        >>> td_module = TDSequence(td_module1, td_module2)
-        >>> params = params1 + params2
-        >>> buffers = buffers1 + buffers2
-        >>> _ = td_module(td, params=params, buffers=buffers)
-        >>> print(td)
-        TensorDict(
-            fields={input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden: Tensor(torch.Size([3, 4]), dtype=torch.float32),
-                hidden_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32),
-                output: Tensor(torch.Size([3, 8]), dtype=torch.float32)},
-            shared=False,
-            batch_size=torch.Size([3]),
-            device=cpu)
-
-        >>> # The module spec aggregates all the input specs:
-        >>> print(td_module.spec)
-        CompositeSpec(
-            hidden: NdUnboundedContinuousTensorSpec(
-                 shape=torch.Size([4]),space=None,device=cpu,dtype=torch.float32,domain=continuous),
-            output: NdUnboundedContinuousTensorSpec(
-                 shape=torch.Size([8]),space=None,device=cpu,dtype=torch.float32,domain=continuous))
-
-    In the vmap case:
-        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
-        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
-        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
-        >>> print(td_vmap)
-
-
-    """
-
-    module: nn.ModuleList
-
-    def __init__(
-        self,
-        *modules: TDModule,
-    ):
-        in_keys_tmp = []
-        out_keys = []
-        for module in modules:
-            in_keys_tmp += module.in_keys
-            out_keys += module.out_keys
-        in_keys = []
-        for in_key in in_keys_tmp:
-            if (in_key not in in_keys) and (in_key not in out_keys):
-                in_keys.append(in_key)
-        if not len(in_keys):
-            raise RuntimeError(
-                "in_keys empty. Please ensure that there is at least one input "
-                "key that is not part of the output key set."
-            )
-        out_keys = [
-            out_key
-            for i, out_key in enumerate(out_keys)
-            if out_key not in out_keys[i + 1 :]
-        ]
-
-        super().__init__(
-            spec=None,
-            module=nn.ModuleList(list(modules)),
-            in_keys=in_keys,
-            out_keys=out_keys,
-        )
-
-    @property
-    def param_len(self) -> List[int]:
-        param_list = []
-        prev = 0
-        for module in self.module:
-            param_list.append(len(module.module.param_names) + prev)
-            prev = param_list[-1]
-        return param_list
-
-    @property
-    def buffer_len(self) -> List[int]:
-        buffer_list = []
-        prev = 0
-        for module in self.module:
-            buffer_list.append(len(module.module.buffer_names) + prev)
-            prev = buffer_list[-1]
-        return buffer_list
-
-    def _split_param(
-        self, param_list: Iterable[Tensor], params_or_buffers: str
-    ) -> Iterable[Iterable[Tensor]]:
-        if params_or_buffers == "params":
-            list_out = self.param_len
-        elif params_or_buffers == "buffers":
-            list_out = self.buffer_len
-        list_in = [0] + list_out[:-1]
-        out = []
-        for a, b in zip(list_in, list_out):
-            out.append(param_list[a:b])
-        return out
-
-    def forward(self, tensordict: _TensorDict, **kwargs) -> _TensorDict:
-        if "params" in kwargs and "buffers" in kwargs:
-            param_splits = self._split_param(kwargs["params"], "params")
-            buffer_splits = self._split_param(kwargs["buffers"], "buffers")
-            kwargs_pruned = {
-                key: item
-                for key, item in kwargs.items()
-                if key not in ("params", "buffers")
-            }
-            for i, (module, param, buffer) in enumerate(
-                zip(self.module, param_splits, buffer_splits)
-            ):
-                if "vmap" in kwargs_pruned and i > 0:
-                    # the tensordict is already expended
-                    kwargs_pruned["vmap"] = (0, 0, *(0,) * len(module.in_keys))
-                tensordict = module(
-                    tensordict, params=param, buffers=buffer, **kwargs_pruned
-                )
-
-        elif "params" in kwargs:
-            param_splits = self._split_param(kwargs["params"], "params")
-            kwargs_pruned = {
-                key: item for key, item in kwargs.items() if key not in ("params",)
-            }
-            for i, (module, param) in enumerate(zip(self.module, param_splits)):
-                if "vmap" in kwargs_pruned and i > 0:
-                    # the tensordict is already expended
-                    kwargs_pruned["vmap"] = (0, *(0,) * len(module.in_keys))
-                tensordict = module(tensordict, params=param, **kwargs_pruned)
-
-        elif not len(kwargs):
-            for module in self.module:
-                tensordict = module(tensordict)
-        else:
-            raise RuntimeError(
-                "TDSequence does not support keyword arguments other than 'params', 'buffers' and 'vmap'"
-            )
-
-        return tensordict
-
-    def __len__(self):
-        return len(self.module)
-
-    def __getitem__(self, index: Union[int, slice]) -> TDModule:
-        return self.module.__getitem__(index)
-
-    def __setitem__(self, index: int, tdmodule: TDModule) -> None:
-        return self.module.__setitem__(idx=index, module=tdmodule)
-
-    def __delitem__(self, index: Union[int, slice]) -> None:
-        self.module.__delitem__(idx=index)
-
-    @property
-    def spec(self):
-        kwargs = {}
-        for layer in self.module:
-            out_key = layer.out_keys[0]
-            spec = layer.spec
-            if spec is None:
-                # By default, we consider that unspecified specs are unbounded.
-                spec = UnboundedContinuousTensorSpec()
-            if not isinstance(spec, TensorSpec):
-                raise RuntimeError(
-                    f"TDSequence.spec requires all specs to be valid TensorSpec objects. Got "
-                    f"{type(layer.spec)}"
-                )
-            kwargs[out_key] = spec
-        return CompositeSpec(**kwargs)
-
-    def make_functional_with_buffers(self, clone: bool = False):
-        """
-        Transforms a stateful module in a functional module and returns its parameters and buffers.
-        Unlike functorch.make_functional_with_buffers, this method supports lazy modules.
-
-        Returns:
-            A tuple of parameter and buffer tuples
-
-        Examples:
-            >>> from torchrl.data import NdUnboundedContinuousTensorSpec, TensorDict
-            >>> lazy_module1 = nn.LazyLinear(4)
-            >>> lazy_module2 = nn.LazyLinear(3)
-            >>> spec1 = NdUnboundedContinuousTensorSpec(18)
-            >>> spec2 = NdUnboundedContinuousTensorSpec(4)
-            >>> td_module1 = TDModule(spec1, lazy_module1, ["some_input"], ["hidden"])
-            >>> td_module2 = TDModule(spec2, lazy_module2, ["hidden"], ["some_output"])
-            >>> td_module = TDSequence(td_module1, td_module2)
-            >>> _, (params, buffers) = td_module.make_functional_with_buffers()
-            >>> print(params[0].shape) # the lazy module has been initialized
-            torch.Size([4, 18])
-            >>> print(td_module(
-            ...    TensorDict({'some_input': torch.randn(18)}, batch_size=[]),
-            ...    params=params,
-            ...    buffers=buffers))
-            TensorDict(
-                fields={
-                    some_input: Tensor(torch.Size([18]), dtype=torch.float32),
-                    hidden: Tensor(torch.Size([4]), dtype=torch.float32),
-                    some_output: Tensor(torch.Size([3]), dtype=torch.float32)},
-                batch_size=torch.Size([]),
-                device=cpu,
-                is_shared=False)
-
-        """
-        if clone:
-            self_copy = copy(self)
-            self_copy.module = copy(self_copy.module)
-        else:
-            self_copy = self
-        params = []
-        buffers = []
-        for i, module in enumerate(self.module):
-            self_copy.module[i], (
-                _params,
-                _buffers,
-            ) = module.make_functional_with_buffers()
-            params.extend(_params)
-            buffers.extend(_buffers)
-        return self_copy, (params, buffers)
-
-    def get_dist(
-        self,
-        tensordict: _TensorDict,
-        **kwargs,
-    ) -> Tuple[torch.distributions.Distribution, ...]:
-        L = len(self.module)
-
-        if isinstance(self.module[-1], ProbabilisticTDModule):
-            if "params" in kwargs and "buffers" in kwargs:
-                param_splits = self._split_param(kwargs["params"], "params")
-                buffer_splits = self._split_param(kwargs["buffers"], "buffers")
-                kwargs_pruned = {
-                    key: item
-                    for key, item in kwargs.items()
-                    if key not in ("params", "buffers")
-                }
-                for i, (module, param, buffer) in enumerate(
-                    zip(self.module, param_splits, buffer_splits)
-                ):
-                    if "vmap" in kwargs_pruned and i > 0:
-                        # the tensordict is already expended
-                        kwargs_pruned["vmap"] = (0, 0, *(0,) * len(module.in_keys))
-                    if i < L - 1:
-                        tensordict = module(
-                            tensordict, params=param, buffers=buffer, **kwargs_pruned
-                        )
-                    else:
-                        out = module.get_dist(
-                            tensordict, params=param, buffers=buffer, **kwargs_pruned
-                        )
-
-            elif "params" in kwargs:
-                param_splits = self._split_param(kwargs["params"], "params")
-                kwargs_pruned = {
-                    key: item for key, item in kwargs.items() if key not in ("params",)
-                }
-                for i, (module, param) in enumerate(zip(self.module, param_splits)):
-                    if "vmap" in kwargs_pruned and i > 0:
-                        # the tensordict is already expended
-                        kwargs_pruned["vmap"] = (0, *(0,) * len(module.in_keys))
-                    if i < L - 1:
-                        tensordict = module(tensordict, params=param, **kwargs_pruned)
-                    else:
-                        out = module.get_dist(tensordict, params=param, **kwargs_pruned)
-
-            elif not len(kwargs):
-                for i, module in enumerate(self.module):
-                    if i < L - 1:
-                        tensordict = module(tensordict)
-                    else:
-                        out = module.get_dist(tensordict)
-            else:
-                raise RuntimeError(
-                    "TDSequence does not support keyword arguments other than 'params', 'buffers' and 'vmap'"
-                )
-
-            return out
-        else:
-            raise RuntimeError(
-                "Cannot call get_dist on a sequence of tensordicts that does not end with a probabilistic TensorDict"
-            )
 
 
 class TDModuleWrapper(nn.Module):

--- a/torchrl/modules/td_module/common.py
+++ b/torchrl/modules/td_module/common.py
@@ -35,16 +35,16 @@ __all__ = [
 
 
 def _forward_hook_safe_action(module, tensordict_in, tensordict_out):
-    if not module.spec.is_in(tensordict_out.get(module.out_keys[0])):
+    if not module.spec.is_in(tensordict_out.get("action")):
         try:
             tensordict_out.set_(
-                module.out_keys[0],
-                module.spec.project(tensordict_out.get(module.out_keys[0])),
+                "action",
+                module.spec.project(tensordict_out.get("action")),
             )
         except RuntimeError:
             tensordict_out.set(
-                module.out_keys[0],
-                module.spec.project(tensordict_out.get(module.out_keys[0])),
+                "action",
+                module.spec.project(tensordict_out.get("action")),
             )
 
 

--- a/torchrl/modules/td_module/deprec.py
+++ b/torchrl/modules/td_module/deprec.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from _warnings import warn
+from copy import deepcopy
+from typing import Union, Callable, Sequence, Type, Optional, Tuple
+
+import torch
+from torch import Tensor, nn, distributions as d
+
+from torchrl.data import TensorSpec, DEVICE_TYPING
+from torchrl.data.tensordict.tensordict import _TensorDict
+from torchrl.envs.utils import exploration_mode
+from torchrl.modules import TDModule, Delta, distributions_maps
+
+
+class ProbabilisticTDModule(TDModule):
+    """
+    DEPRECATED
+
+    A probabilistic TD Module.
+    ProbabilisticTDModule is a special case of a TDModule where the output is sampled given some rule, specified by
+    the input `default_interaction_mode` argument and the `exploration_mode()` global function.
+
+    A ProbabilisticTDModule instance has two main features:
+    - It reads and writes TensorDict objects
+    - It uses a real mapping R^n -> R^m to create a distribution in R^d from which values can be sampled or computed.
+    When the __call__ / forward method is called, a distribution is created, and a value computed (using the 'mean',
+    'mode', 'median' attribute or the 'rsample', 'sample' method).
+
+    By default, ProbabilisticTDModule distribution class is a Delta distribution, making ProbabilisticTDModule a
+    simple wrapper around a deterministic mapping function (i.e. it can be used interchangeably with its parent
+    TDModule).
+
+    Args:
+        module (nn.Module): a nn.Module used to map the input to the output parameter space. Can be a functional
+            module (FunctionalModule or FunctionalModuleWithBuffers), in which case the `forward` method will expect
+            the params (and possibly) buffers keyword arguments.
+        spec (TensorSpec): specs of the first output tensor. Used when calling td_module.random() to generate random
+            values in the target space.
+        in_keys (iterable of str): keys to be read from input tensordict and passed to the module. If it
+            contains more than one element, the values will be passed in the order given by the in_keys iterable.
+        out_keys (iterable of str): keys to be written to the input tensordict. The length of out_keys must match the
+            number of tensors returned by the distribution sampling method plus the extra tensors returned by the
+            module.
+        distribution_class (Type, optional): a torch.distributions.Distribution class to be used for sampling.
+            Default is Delta.
+        distribution_kwargs (dict, optional): kwargs to be passed to the distribution.
+        default_interaction_mode (str, optional): default method to be used to retrieve the output value. Should be one of:
+            'mode', 'median', 'mean' or 'random' (in which case the value is sampled randomly from the distribution).
+            Default is 'mode'.
+            Note: When a sample is drawn, the `ProbabilisticTDModule` instance will fist look for the interaction mode
+            dictated by the `exploration_mode()` global function. If this returns `None` (its default value),
+            then the `default_interaction_mode` of the `ProbabilisticTDModule` instance will be used.
+            Note that DataCollector instances will use `set_exploration_mode` to `"random"` by default.
+        return_log_prob (bool, optional): if True, the log-probability of the distribution sample will be written in the
+            tensordict with the key `f'{in_keys[0]}_log_prob'`. Default is `False`.
+        safe (bool, optional): if True, the value of the sample is checked against the input spec. Out-of-domain sampling can
+            occur because of exploration policies or numerical under/overflow issues. As for the `spec` argument,
+            this check will only occur for the distribution sample, but not the other tensors returned by the input
+            module. If the sample is out of bounds, it is projected back onto the desired space using the
+            `TensorSpec.project`
+            method.
+            Default is `False`.
+        save_dist_params (bool, optional): if True, the parameters of the distribution (i.e. the output of the module)
+            will be written to the tensordict along with the sample. Those parameters can be used to
+            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
+            used to sample the action and the updated distribution in PPO).
+            Default is `False`.
+        cache_dist (bool, optional): if True, the parameters of the distribution (i.e. the output of the module)
+            will be written to the tensordict along with the sample. Those parameters can be used to
+            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
+            used to sample the action and the updated distribution in PPO).
+            Default is `False`.
+
+    Examples:
+        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import TanhNormal
+        >>> import functorch, torch
+        >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
+        >>> spec = NdUnboundedContinuousTensorSpec(4)
+        >>> module = torch.nn.GRUCell(4, 8)
+        >>> module_func, params, buffers = functorch.make_functional_with_buffers(module)
+        >>> td_module = ProbabilisticTDModule(
+        ...    module=module_func,
+        ...    spec=spec,
+        ...    in_keys=["input"],
+        ...    out_keys=["output"],
+        ...    distribution_class=TanhNormal,
+        ...    return_log_prob=True,
+        ...    )
+        >>> _ = td_module(td, params=params, buffers=buffers)
+        >>> print(td)
+        TensorDict(
+            fields={
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                output: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                output_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
+            batch_size=torch.Size([3]),
+            device=cpu,
+            is_shared=False)
+
+        >>> # In the vmap case, the tensordict is again expended to match the batch:
+        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
+        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
+        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
+        >>> print(td_vmap)
+        TensorDict(
+            fields={
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                output: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                output_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
+            batch_size=torch.Size([3]),
+            device=cpu,
+            is_shared=False)
+
+    """
+
+    def __init__(
+        self,
+        module: Union[Callable[[Tensor], Tensor], nn.Module],
+        spec: TensorSpec,
+        in_keys: Sequence[str],
+        out_keys: Sequence[str],
+        distribution_class: Type = Delta,
+        distribution_kwargs: Optional[dict] = None,
+        default_interaction_mode: str = "mode",
+        _n_empirical_est: int = 1000,
+        return_log_prob: bool = False,
+        safe: bool = False,
+        save_dist_params: bool = False,
+        cache_dist: bool = False,
+    ):
+        warn(
+            "ProbabilisticTDModule will be deprecated soon, consider using ProbabilisticTensorDictModule instead."
+        )
+        super().__init__(
+            spec=spec,
+            module=module,
+            out_keys=out_keys,
+            in_keys=in_keys,
+            safe=safe,
+        )
+
+        self.save_dist_params = save_dist_params
+        self._n_empirical_est = _n_empirical_est
+        self.cache_dist = cache_dist if hasattr(distribution_class, "update") else False
+        self._dist = None
+
+        if isinstance(distribution_class, str):
+            distribution_class = distributions_maps.get(distribution_class.lower())
+        self.distribution_class = distribution_class
+        self.distribution_kwargs = (
+            distribution_kwargs if distribution_kwargs is not None else dict()
+        )
+        self.return_log_prob = return_log_prob
+
+        self.default_interaction_mode = default_interaction_mode
+        self.interact = False
+
+    def get_dist(
+        self,
+        tensordict: _TensorDict,
+        **kwargs,
+    ) -> Tuple[torch.distributions.Distribution, ...]:
+        """Calls the module using the tensors retrieved from the 'in_keys' attribute and returns a distribution
+        using its output.
+
+        Args:
+            tensordict (_TensorDict): tensordict with the input values for the creation of the distribution.
+
+        Returns:
+            a distribution along with other tensors returned by the module.
+
+        """
+        tensors = [tensordict.get(key, None) for key in self.in_keys]
+        out_tensors = self._call_module(tensors, **kwargs)
+        if isinstance(out_tensors, Tensor):
+            out_tensors = (out_tensors,)
+        if self.save_dist_params:
+            for i, _tensor in enumerate(out_tensors):
+                tensordict.set(f"{self.out_keys[0]}_dist_param_{i}", _tensor)
+        dist, num_params = self.build_dist_from_params(out_tensors)
+        tensors = out_tensors[num_params:]
+
+        return (dist, *tensors)
+
+    def build_dist_from_params(
+        self, params: Tuple[Tensor, ...]
+    ) -> Tuple[d.Distribution, int]:
+        """Given a tuple of temsors, returns a distribution object and the number of parameters used for it.
+
+        Args:
+            params (Tuple[Tensor, ...]): tensors to be used for the distribution construction.
+
+        Returns:
+            a distribution object and the number of parameters used for its construction.
+
+        """
+        num_params = (
+            getattr(self.distribution_class, "num_params")
+            if hasattr(self.distribution_class, "num_params")
+            else 1
+        )
+        if self.cache_dist and self._dist is not None:
+            self._dist.update(*params[:num_params])
+            dist = self._dist
+        else:
+            dist = self.distribution_class(
+                *params[:num_params], **self.distribution_kwargs
+            )
+            if self.cache_dist:
+                self._dist = dist
+        return dist, num_params
+
+    def forward(
+        self,
+        tensordict: _TensorDict,
+        tensordict_out: Optional[_TensorDict] = None,
+        **kwargs,
+    ) -> _TensorDict:
+
+        dist, *tensors = self.get_dist(tensordict, **kwargs)
+        out_tensor = self._dist_sample(
+            dist, *tensors, interaction_mode=exploration_mode()
+        )
+        tensordict_out = self._write_to_tensordict(
+            tensordict,
+            [out_tensor] + list(tensors),
+            tensordict_out,
+            vmap=kwargs.get("vmap", 0),
+        )
+        if self.return_log_prob:
+            log_prob = dist.log_prob(out_tensor)
+            tensordict_out.set("_".join([self.out_keys[0], "log_prob"]), log_prob)
+        return tensordict_out
+
+    def log_prob(self, tensordict: _TensorDict, **kwargs) -> _TensorDict:
+        """
+        Samples/computes an action using the module and writes this value onto the input tensordict along
+        with its log-probability.
+
+        Args:
+            tensordict (_TensorDict): tensordict containing the in_keys specified in the initializer.
+
+        Returns:
+            the same tensordict with the out_keys values added/updated as well as a
+                f"{out_keys[0]}_log_prob" key containing the log-probability of the first output.
+
+        """
+        dist, *_ = self.get_dist(tensordict, **kwargs)
+        lp = dist.log_prob(tensordict.get(self.out_keys[0]))
+        tensordict.set(self.out_keys[0] + "_log_prob", lp)
+        return tensordict
+
+    def _dist_sample(
+        self,
+        dist: d.Distribution,
+        *tensors: Tensor,
+        interaction_mode: bool = None,
+        eps: float = None,
+    ) -> Tensor:
+        if interaction_mode is None:
+            interaction_mode = self.default_interaction_mode
+        if not isinstance(dist, d.Distribution):
+            raise TypeError(f"type {type(dist)} not recognised by _dist_sample")
+
+        if interaction_mode == "mode":
+            if hasattr(dist, "mode"):
+                return dist.mode
+            else:
+                raise NotImplementedError(
+                    f"method {type(dist)}.mode is not implemented"
+                )
+
+        elif interaction_mode == "median":
+            if hasattr(dist, "median"):
+                return dist.median
+            else:
+                raise NotImplementedError(
+                    f"method {type(dist)}.median is not implemented"
+                )
+
+        elif interaction_mode == "mean":
+            try:
+                return dist.mean
+            except AttributeError:
+                if dist.has_rsample:
+                    return dist.rsample((self._n_empirical_est,)).mean(0)
+                else:
+                    return dist.sample((self._n_empirical_est,)).mean(0)
+
+        elif interaction_mode == "random":
+            if dist.has_rsample:
+                return dist.rsample()
+            else:
+                return dist.sample()
+        elif interaction_mode == "net_output":
+            if len(tensors) > 1:
+                raise RuntimeError(
+                    "Multiple values passed to _dist_sample when trying to return a single action "
+                    "tensor."
+                )
+            return tensors[0]
+        else:
+            raise NotImplementedError(f"unknown interaction_mode {interaction_mode}")
+
+    @property
+    def device(self):
+        for p in self.parameters():
+            return p.device
+        return torch.device("cpu")
+
+    def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> ProbabilisticTDModule:
+        if self.spec is not None:
+            self.spec = self.spec.to(dest)
+        out = super().to(dest)
+        return out
+
+    def __deepcopy__(self, memodict={}):
+        self._dist = None
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memodict[id(self)] = result
+        for k, v in self.__dict__.items():
+            setattr(result, k, deepcopy(v, memodict))
+        return result
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(module={self.module}, distribution_class={self.distribution_class}, device={self.device})"
+
+
+class ProbabilisticActor_deprecated(ProbabilisticTDModule):
+    """
+    General class for probabilistic actors in RL.
+    The Actor class comes with default values for the in_keys and out_keys
+    arguments (["observation"] and ["action"], respectively).
+
+    Examples:
+        >>> from torchrl.data import TensorDict, NdBoundedTensorSpec
+        >>> from torchrl.modules import Actor, TanhNormal
+        >>> import torch, functorch
+        >>> td = TensorDict({"observation": torch.randn(3, 4)}, [3,])
+        >>> action_spec = NdBoundedTensorSpec(shape=torch.Size([4]),
+        ...    minimum=-1, maximum=1)
+        >>> module = torch.nn.Linear(4, 8)
+        >>> fmodule, params, buffers = functorch.make_functional_with_buffers(
+        ...     module)
+        >>> td_module = ProbabilisticActor_deprecated(
+        ...    module=fmodule,
+        ...    spec=action_spec,
+        ...    distribution_class=TanhNormal,
+        ...    )
+        >>> td_module(td, params=params, buffers=buffers)
+        >>> print(td.get("action"))
+
+    """
+
+    def __init__(
+        self,
+        *args,
+        in_keys: Optional[Sequence[str]] = None,
+        out_keys: Optional[Sequence[str]] = None,
+        **kwargs,
+    ):
+        if in_keys is None:
+            in_keys = ["observation"]
+        if out_keys is None:
+            out_keys = ["action"]
+
+        super().__init__(
+            *args,
+            in_keys=in_keys,
+            out_keys=out_keys,
+            **kwargs,
+        )

--- a/torchrl/modules/td_module/exploration.py
+++ b/torchrl/modules/td_module/exploration.py
@@ -40,7 +40,7 @@ class EGreedyWrapper(TDModuleWrapper):
         >>> torch.manual_seed(0)
         >>> spec = NdBoundedTensorSpec(-1, 1, torch.Size([4]))
         >>> module = torch.nn.Linear(4, 4, bias=False)
-        >>> policy = Actor(spec, module=module)
+        >>> policy = Actor(spec=spec, module=module)
         >>> explorative_policy = EGreedyWrapper(policy, eps_init=0.2)
         >>> td = TensorDict({"observation": torch.zeros(10, 4)}, batch_size=[10])
         >>> print(explorative_policy(td).get("action"))

--- a/torchrl/modules/td_module/exploration.py
+++ b/torchrl/modules/td_module/exploration.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 import numpy as np
 import torch
 
+from torchrl.data import CompositeSpec
 from torchrl.data.utils import expand_as_right
 from torchrl.envs.utils import exploration_mode
 from torchrl.modules.td_module.common import (
@@ -201,7 +202,12 @@ class OrnsteinUhlenbeckProcessWrapper(TDModuleWrapper):
             )
         self.annealing_num_steps = annealing_num_steps
         self.register_buffer("eps", torch.tensor([eps_init]))
-        self.out_keys = list(self.td_module.out_keys) + [self.ou.out_keys]
+        self.out_keys = list(self.td_module.out_keys) + self.ou.out_keys
+        self._spec = CompositeSpec(
+            **self.td_module._spec, **{key: None for key in self.ou.out_keys}
+        )
+        if len(set(self.out_keys)) != len(self.out_keys):
+            raise RuntimeError(f"Got multiple identical output keys: {self.out_keys}")
         self.safe = safe
         if self.safe:
             self.register_forward_hook(_forward_hook_safe_action)
@@ -268,7 +274,7 @@ class _OrnsteinUhlenbeckProcess:
         self.key = key
         self._noise_key = "_ou_prev_noise"
         self._steps_key = "_ou_steps"
-        self.out_keys = [self.key, self.noise_key, self.steps_key]
+        self.out_keys = [self.noise_key, self.steps_key]
 
     @property
     def noise_key(self):

--- a/torchrl/modules/td_module/probabilistic.py
+++ b/torchrl/modules/td_module/probabilistic.py
@@ -15,7 +15,7 @@ from torchrl.data import TensorSpec
 from torchrl.data.tensordict.tensordict import _TensorDict
 from torchrl.envs.utils import exploration_mode
 from torchrl.modules.distributions import distributions_maps, Delta
-from torchrl.modules.td_module.common import TDModule
+from torchrl.modules.td_module.common import TDModule, _check_all_str
 
 __all__ = ["ProbabilisticTensorDictModule"]
 
@@ -167,6 +167,7 @@ class ProbabilisticTensorDictModule(TDModule):
                 )
         module_out_keys = module.out_keys
         self.out_key_sample = out_key_sample
+        _check_all_str(self.out_key_sample)
         out_key_sample = [key for key in out_key_sample if key not in module_out_keys]
         self._requires_sample = bool(len(out_key_sample))
         out_keys = out_key_sample + module_out_keys
@@ -174,6 +175,7 @@ class ProbabilisticTensorDictModule(TDModule):
             module=module, spec=spec, in_keys=in_keys, out_keys=out_keys, safe=safe
         )
         self.dist_param_keys = dist_param_keys
+        _check_all_str(self.dist_param_keys)
 
         self.default_interaction_mode = default_interaction_mode
         if isinstance(distribution_class, str):

--- a/torchrl/modules/td_module/probabilistic.py
+++ b/torchrl/modules/td_module/probabilistic.py
@@ -1,0 +1,317 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import re
+from copy import deepcopy
+from textwrap import indent
+from typing import Sequence, Union, Type, Optional, Tuple
+
+from torch import Tensor
+from torch import distributions as d
+
+from torchrl.data import TensorSpec
+from torchrl.data.tensordict.tensordict import _TensorDict
+from torchrl.envs.utils import exploration_mode
+from torchrl.modules.distributions import distributions_maps, Delta
+from torchrl.modules.td_module.common import TDModule
+
+__all__ = ["ProbabilisticTensorDictModule"]
+
+
+class ProbabilisticTensorDictModule(TDModule):
+    """
+    A probabilistic TD Module.
+    `ProbabilisticTDModule` is a special case of a TDModule where the output is
+    sampled given some rule, specified by the input `default_interaction_mode`
+    argument and the `exploration_mode()` global function.
+
+    It consists in a wrapper around another TDModule that returns a tensordict
+    updated with the distribution parameters. `ProbabilisticTensorDictModule` is
+    responsible for constructing the distribution (through the `get_dist()` method)
+    and/or sampling from this distribution (through a regular `__call__()` to the
+    module).
+
+    A `ProbabilisticTensorDictModule` instance has two main features:
+    - It reads and writes TensorDict objects
+    - It uses a real mapping R^n -> R^m to create a distribution in R^d from
+    which values can be sampled or computed.
+    When the `__call__` / `forward` method is called, a distribution is created,
+    and a value computed (using the 'mean', 'mode', 'median' attribute or
+    the 'rsample', 'sample' method). The sampling step is skipped if the
+    inner TDModule has already created the desired key-value pair.
+
+    By default, ProbabilisticTensorDictModule distribution class is a Delta
+    distribution, making ProbabilisticTensorDictModule a simple wrapper around
+    a deterministic mapping function.
+
+    Args:
+        module (nn.Module): a nn.Module used to map the input to the output parameter space. Can be a functional
+            module (FunctionalModule or FunctionalModuleWithBuffers), in which case the `forward` method will expect
+            the params (and possibly) buffers keyword arguments.
+        dist_param_keys (str or iterable of str): key(s) that will be produced
+            by the inner TDModule and that will be used to build the distribution.
+            Importantly, those keys must match the keywords used by the distribution
+            class of interest, e.g. `"loc"` and `"scale"` for the Normal distribution
+            and similar.
+        out_key_sample (str or iterable of str): keys where the sampled values will be
+            written. Importantly, if this key is part of the `out_keys` of the inner model,
+            the sampling step will be skipped.
+        spec (TensorSpec): specs of the first output tensor. Used when calling td_module.random() to generate random
+            values in the target space.
+        distribution_class (Type, optional): a torch.distributions.Distribution class to be used for sampling.
+            Default is Delta.
+        distribution_kwargs (dict, optional): kwargs to be passed to the distribution.
+        default_interaction_mode (str, optional): default method to be used to retrieve the output value. Should be one of:
+            'mode', 'median', 'mean' or 'random' (in which case the value is sampled randomly from the distribution).
+            Default is 'mode'.
+            Note: When a sample is drawn, the `ProbabilisticTDModule` instance will fist look for the interaction mode
+            dictated by the `exploration_mode()` global function. If this returns `None` (its default value),
+            then the `default_interaction_mode` of the `ProbabilisticTDModule` instance will be used.
+            Note that DataCollector instances will use `set_exploration_mode` to `"random"` by default.
+        return_log_prob (bool, optional): if True, the log-probability of the distribution sample will be written in the
+            tensordict with the key `f'{in_keys[0]}_log_prob'`. Default is `False`.
+        safe (bool, optional): if True, the value of the sample is checked against the input spec. Out-of-domain sampling can
+            occur because of exploration policies or numerical under/overflow issues. As for the `spec` argument,
+            this check will only occur for the distribution sample, but not the other tensors returned by the input
+            module. If the sample is out of bounds, it is projected back onto the desired space using the
+            `TensorSpec.project`
+            method.
+            Default is `False`.
+        save_dist_params (bool, optional): if True, the parameters of the distribution (i.e. the output of the module)
+            will be written to the tensordict along with the sample. Those parameters can be used to
+            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
+            used to sample the action and the updated distribution in PPO).
+            Default is `False`.
+        cache_dist (bool, optional): if True, the parameters of the distribution (i.e. the output of the module)
+            will be written to the tensordict along with the sample. Those parameters can be used to
+            re-compute the original distribution later on (e.g. to compute the divergence between the distribution
+            used to sample the action and the updated distribution in PPO).
+            Default is `False`.
+
+    Examples:
+        >>> from torchrl.modules.td_module import ProbabilisticTensorDictModule
+        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import  TanhNormal, NormalParamWrapper
+        >>> import functorch, torch
+        >>> td = TensorDict({"input": torch.randn(3, 4), "hidden": torch.randn(3, 8)}, [3,])
+        >>> spec = NdUnboundedContinuousTensorSpec(4)
+        >>> net = NormalParamWrapper(torch.nn.GRUCell(4, 8))
+        >>> fnet, params, buffers = functorch.make_functional_with_buffers(net)
+        >>> module = TDModule(fnet, in_keys=["input", "hidden"], out_keys=["loc", "scale"])
+        >>> td_module = ProbabilisticTensorDictModule(
+        ...    module=module,
+        ...    spec=spec,
+        ...    dist_param_keys=["loc", "scale"],
+        ...    out_key_sample=["action"],
+        ...    distribution_class=TanhNormal,
+        ...    return_log_prob=True,
+        ...    )
+        >>> _ = td_module(td, params=params, buffers=buffers)
+        >>> print(td)
+        TensorDict(
+            fields={
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([3, 8]), dtype=torch.float32),
+                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                action: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
+            batch_size=torch.Size([3]),
+            device=cpu,
+            is_shared=False)
+
+        >>> # In the vmap case, the tensordict is again expended to match the batch:
+        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
+        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
+        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
+        >>> print(td_vmap)
+        TensorDict(
+            fields={
+                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
+                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                action: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([4, 3, 1]), dtype=torch.float32)},
+            batch_size=torch.Size([4, 3]),
+            device=cpu,
+            is_shared=False)
+
+    """
+
+    def __init__(
+        self,
+        module: TDModule,
+        dist_param_keys: Union[str, Sequence[str]],
+        out_key_sample: Union[str, Sequence[str]],
+        spec: Optional[TensorSpec] = None,
+        safe: bool = False,
+        default_interaction_mode: str = "mode",
+        distribution_class: Type = Delta,
+        distribution_kwargs: Optional[dict] = None,
+        return_log_prob: bool = False,
+        cache_dist: bool = False,
+        _n_empirical_est: int = 1000,
+    ):
+        in_keys = module.in_keys
+
+        # if the module returns the sampled key we wont be sampling it again
+        # then ProbabilisticTensorDictModule is presumably used to return the distribution using `get_dist`
+        if isinstance(dist_param_keys, str):
+            dist_param_keys = [dist_param_keys]
+        if isinstance(out_key_sample, str):
+            out_key_sample = [out_key_sample]
+        for key in dist_param_keys:
+            if key not in module.out_keys:
+                raise RuntimeError(
+                    f"The key {key} could not be found in the wrapped module `{type(module)}.out_keys`."
+                )
+        module_out_keys = module.out_keys
+        self.out_key_sample = out_key_sample
+        out_key_sample = [key for key in out_key_sample if key not in module_out_keys]
+        self._requires_sample = bool(len(out_key_sample))
+        out_keys = out_key_sample + module_out_keys
+        super().__init__(
+            module=module, spec=spec, in_keys=in_keys, out_keys=out_keys, safe=safe
+        )
+        self.dist_param_keys = dist_param_keys
+
+        self.default_interaction_mode = default_interaction_mode
+        if isinstance(distribution_class, str):
+            distribution_class = distributions_maps.get(distribution_class.lower())
+        self.distribution_class = distribution_class
+        self.distribution_kwargs = (
+            distribution_kwargs if distribution_kwargs is not None else dict()
+        )
+        self._n_empirical_est = _n_empirical_est
+        self._dist = None
+        self.cache_dist = cache_dist if hasattr(distribution_class, "update") else False
+        self.return_log_prob = return_log_prob
+
+    def _call_module(self, tensordict: _TensorDict, **kwargs) -> _TensorDict:
+        return self.module(tensordict, **kwargs)
+
+    def make_functional_with_buffers(self, clone: bool = False):
+        module_params = self.parameters(recurse=False)
+        if len(list(module_params)):
+            raise RuntimeError(
+                "make_functional_with_buffers cannot be called on ProbabilisticTensorDictModule"
+                "that contain parameters on the outer level."
+            )
+        if clone:
+            self_copy = deepcopy(self)
+        else:
+            self_copy = self
+
+        module, other = self_copy.module.make_functional_with_buffers(clone=False)
+        self_copy.module = module
+        return self_copy, other
+
+    def get_dist(
+        self,
+        tensordict: _TensorDict,
+        tensordict_out: Optional[_TensorDict] = None,
+        **kwargs,
+    ) -> Tuple[d.Distribution, _TensorDict]:
+        tensordict_out = self._call_module(
+            tensordict, tensordict_out=tensordict_out, **kwargs
+        )
+        dist = self.build_dist_from_params(tensordict_out)
+        return dist, tensordict_out
+
+    def build_dist_from_params(self, tensordict_out: _TensorDict) -> d.Distribution:
+        try:
+            dist = self.distribution_class(
+                **tensordict_out.select(*self.dist_param_keys)
+            )
+        except TypeError as err:
+            if "an unexpected keyword argument" in str(err):
+                raise TypeError(
+                    "distribution keywords and tensordict keys indicated by ProbabilisticTensorDictModule.dist_param_keys must match."
+                    f"Got this error message: \n{indent(str(err), 4 * ' ')}\nwith dist_param_keys={self.dist_param_keys}"
+                )
+            elif re.search(r"missing.*required positional arguments", str(err)):
+                raise TypeError(
+                    f"TensorDict with keys {tensordict_out.keys()} does not match the distribution {self.distribution_class} keywords."
+                )
+            else:
+                raise err
+        return dist
+
+    def forward(
+        self,
+        tensordict: _TensorDict,
+        tensordict_out: Optional[_TensorDict] = None,
+        **kwargs,
+    ) -> _TensorDict:
+
+        dist, tensordict_out = self.get_dist(
+            tensordict, tensordict_out=tensordict_out, **kwargs
+        )
+        if self._requires_sample:
+            out_tensors = self._dist_sample(dist, interaction_mode=exploration_mode())
+            if isinstance(out_tensors, Tensor):
+                out_tensors = (out_tensors,)
+            tensordict_out.update(
+                {key: value for key, value in zip(self.out_key_sample, out_tensors)}
+            )
+            if self.return_log_prob:
+                log_prob = dist.log_prob(*out_tensors)
+                tensordict_out.set("sample_log_prob", log_prob)
+        elif self.return_log_prob:
+            out_tensors = [tensordict_out.get(key) for key in self.out_key_sample]
+            log_prob = dist.log_prob(*out_tensors)
+            tensordict_out.set("sample_log_prob", log_prob)
+            # raise RuntimeError(
+            #     "ProbabilisticTensorDictModule.return_log_prob = True is incompatible with settings in which "
+            #     "the submodule is responsible for sampling. To manually gather the log-probability, call first "
+            #     "\n>>> dist, tensordict = tensordict_module.get_dist(tensordict)"
+            #     "\n>>> tensordict.set('sample_log_prob', dist.log_prob(tensordict.get(sample_key))"
+            # )
+        return tensordict_out
+
+    def _dist_sample(
+        self,
+        dist: d.Distribution,
+        *tensors: Tensor,
+        interaction_mode: bool = None,
+    ) -> Union[Tuple[Tensor], Tensor]:
+        if interaction_mode is None:
+            interaction_mode = self.default_interaction_mode
+        if not isinstance(dist, d.Distribution):
+            raise TypeError(f"type {type(dist)} not recognised by _dist_sample")
+
+        if interaction_mode == "mode":
+            if hasattr(dist, "mode"):
+                return dist.mode
+            else:
+                raise NotImplementedError(
+                    f"method {type(dist)}.mode is not implemented"
+                )
+
+        elif interaction_mode == "median":
+            if hasattr(dist, "median"):
+                return dist.median
+            else:
+                raise NotImplementedError(
+                    f"method {type(dist)}.median is not implemented"
+                )
+
+        elif interaction_mode == "mean":
+            try:
+                return dist.mean
+            except AttributeError:
+                if dist.has_rsample:
+                    return dist.rsample((self._n_empirical_est,)).mean(0)
+                else:
+                    return dist.sample((self._n_empirical_est,)).mean(0)
+
+        elif interaction_mode == "random":
+            if dist.has_rsample:
+                return dist.rsample()
+            else:
+                return dist.sample()
+        else:
+            raise NotImplementedError(f"unknown interaction_mode {interaction_mode}")

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -1,0 +1,371 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from copy import copy
+from typing import List, Iterable, Union, Tuple
+
+import functorch
+import torch
+from torch import nn, Tensor
+
+from torchrl.data import (
+    UnboundedContinuousTensorSpec,
+    TensorSpec,
+    CompositeSpec,
+)
+from torchrl.data.tensordict.tensordict import _TensorDict
+from torchrl.modules.td_module.common import TDModule
+from torchrl.modules.td_module.probabilistic import ProbabilisticTensorDictModule
+
+__all__ = ["TDSequence"]
+
+
+class TDSequence(TDModule):
+    """
+    A sequence of TDModules.
+    Similarly to `nn.Sequence` which passes a tensor through a chain of mappings that read and write a single tensor
+    each, this module will read and write over a tensordict by querying each of the input modules.
+    When calling a `TDSequence` instance with a functional module, it is expected that the parameter lists (and
+    buffers) will be concatenated in a single list.
+
+    Args:
+         modules (iterable of TDModules): ordered sequence of TDModule instances to be run sequentially.
+
+    TDSequence supportse functional, modular and vmap coding:
+    Examples:
+        >>> from torchrl.modules.td_module import ProbabilisticTensorDictModule
+        >>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
+        >>> from torchrl.modules import  TanhNormal, TDSequence, NormalParamWrapper
+        >>> import torch, functorch
+        >>> td = TensorDict({"input": torch.randn(3, 4)}, [3,])
+        >>> spec1 = NdUnboundedContinuousTensorSpec(4)
+        >>> net1 = NormalParamWrapper(torch.nn.Linear(4, 8))
+        >>> fnet1, params1, buffers1 = functorch.make_functional_with_buffers(net1)
+        >>> fmodule1 = TDModule(fnet1, in_keys=["input"], out_keys=["loc", "scale"])
+        >>> td_module1 = ProbabilisticTensorDictModule(
+        ...    module=fmodule1,
+        ...    spec=spec1,
+        ...    dist_param_keys=["loc", "scale"],
+        ...    out_key_sample=["hidden"],
+        ...    distribution_class=TanhNormal,
+        ...    return_log_prob=True,
+        ...    )
+        >>> spec2 = NdUnboundedContinuousTensorSpec(8)
+        >>> module2 = torch.nn.Linear(4, 8)
+        >>> fmodule2, params2, buffers2 = functorch.make_functional_with_buffers(module2)
+        >>> td_module2 = TDModule(
+        ...    module=fmodule2,
+        ...    spec=spec2,
+        ...    in_keys=["hidden"],
+        ...    out_keys=["output"],
+        ...    )
+        >>> td_module = TDSequence(td_module1, td_module2)
+        >>> params = params1 + params2
+        >>> buffers = buffers1 + buffers2
+        >>> _ = td_module(td, params=params, buffers=buffers)
+        >>> print(td)
+        TensorDict(
+            fields={
+                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32),
+                output: Tensor(torch.Size([3, 8]), dtype=torch.float32)},
+            batch_size=torch.Size([3]),
+            device=cpu,
+            is_shared=False)
+
+        >>> # The module spec aggregates all the input specs:
+        >>> print(td_module.spec)
+        CompositeSpec(
+            hidden: NdUnboundedContinuousTensorSpec(
+                 shape=torch.Size([4]),space=None,device=cpu,dtype=torch.float32,domain=continuous),
+            output: NdUnboundedContinuousTensorSpec(
+                 shape=torch.Size([8]),space=None,device=cpu,dtype=torch.float32,domain=continuous))
+
+    In the vmap case:
+        >>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
+        >>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
+        >>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
+        >>> print(td_vmap)
+        TensorDict(
+            fields={
+                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                hidden: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
+                sample_log_prob: Tensor(torch.Size([4, 3, 1]), dtype=torch.float32),
+                output: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32)},
+            batch_size=torch.Size([4, 3]),
+            device=cpu,
+            is_shared=False)
+
+
+    """
+
+    module: nn.ModuleList
+
+    def __init__(
+        self,
+        *modules: TDModule,
+    ):
+        in_keys_tmp = []
+        out_keys = []
+        for module in modules:
+            in_keys_tmp += module.in_keys
+            out_keys += module.out_keys
+        in_keys = []
+        for in_key in in_keys_tmp:
+            if (in_key not in in_keys) and (in_key not in out_keys):
+                in_keys.append(in_key)
+        if not len(in_keys):
+            raise RuntimeError(
+                "in_keys empty. Please ensure that there is at least one input "
+                "key that is not part of the output key set."
+            )
+        out_keys = [
+            out_key
+            for i, out_key in enumerate(out_keys)
+            if out_key not in out_keys[i + 1 :]
+        ]
+
+        super().__init__(
+            spec=None,
+            module=nn.ModuleList(list(modules)),
+            in_keys=in_keys,
+            out_keys=out_keys,
+        )
+
+    @staticmethod
+    def _find_functional_module(module: TDModule) -> nn.Module:
+        fmodule = module
+        while not isinstance(
+            fmodule, (functorch.FunctionalModule, functorch.FunctionalModuleWithBuffers)
+        ):
+            try:
+                fmodule = fmodule.module
+            except AttributeError:
+                raise AttributeError(
+                    f"couldn't find a functional module in module of type {type(module)}"
+                )
+        return fmodule
+
+    @property
+    def param_len(self) -> List[int]:
+        param_list = []
+        prev = 0
+        for module in self.module:
+            # look for functional module
+            fmodule = self._find_functional_module(module)
+            param_list.append(len(fmodule.param_names) + prev)
+            prev = param_list[-1]
+        return param_list
+
+    @property
+    def buffer_len(self) -> List[int]:
+        buffer_list = []
+        prev = 0
+        for module in self.module:
+            fmodule = self._find_functional_module(module)
+            buffer_list.append(len(fmodule.buffer_names) + prev)
+            prev = buffer_list[-1]
+        return buffer_list
+
+    def _split_param(
+        self, param_list: Iterable[Tensor], params_or_buffers: str
+    ) -> Iterable[Iterable[Tensor]]:
+        if params_or_buffers == "params":
+            list_out = self.param_len
+        elif params_or_buffers == "buffers":
+            list_out = self.buffer_len
+        list_in = [0] + list_out[:-1]
+        out = []
+        for a, b in zip(list_in, list_out):
+            out.append(param_list[a:b])
+        return out
+
+    def forward(self, tensordict: _TensorDict, **kwargs) -> _TensorDict:
+        if "params" in kwargs and "buffers" in kwargs:
+            param_splits = self._split_param(kwargs["params"], "params")
+            buffer_splits = self._split_param(kwargs["buffers"], "buffers")
+            kwargs_pruned = {
+                key: item
+                for key, item in kwargs.items()
+                if key not in ("params", "buffers")
+            }
+            for i, (module, param, buffer) in enumerate(
+                zip(self.module, param_splits, buffer_splits)
+            ):
+                if "vmap" in kwargs_pruned and i > 0:
+                    # the tensordict is already expended
+                    kwargs_pruned["vmap"] = (0, 0, *(0,) * len(module.in_keys))
+                tensordict = module(
+                    tensordict, params=param, buffers=buffer, **kwargs_pruned
+                )
+
+        elif "params" in kwargs:
+            param_splits = self._split_param(kwargs["params"], "params")
+            kwargs_pruned = {
+                key: item for key, item in kwargs.items() if key not in ("params",)
+            }
+            for i, (module, param) in enumerate(zip(self.module, param_splits)):
+                if "vmap" in kwargs_pruned and i > 0:
+                    # the tensordict is already expended
+                    kwargs_pruned["vmap"] = (0, *(0,) * len(module.in_keys))
+                tensordict = module(tensordict, params=param, **kwargs_pruned)
+
+        elif not len(kwargs):
+            for module in self.module:
+                tensordict = module(tensordict)
+        else:
+            raise RuntimeError(
+                "TDSequence does not support keyword arguments other than 'params', 'buffers' and 'vmap'"
+            )
+
+        return tensordict
+
+    def __len__(self):
+        return len(self.module)
+
+    def __getitem__(self, index: Union[int, slice]) -> TDModule:
+        return self.module.__getitem__(index)
+
+    def __setitem__(self, index: int, tdmodule: TDModule) -> None:
+        return self.module.__setitem__(idx=index, module=tdmodule)
+
+    def __delitem__(self, index: Union[int, slice]) -> None:
+        self.module.__delitem__(idx=index)
+
+    @property
+    def spec(self):
+        kwargs = {}
+        for layer in self.module:
+            out_key = layer.out_keys[0]
+            spec = layer.spec
+            if spec is None:
+                # By default, we consider that unspecified specs are unbounded.
+                spec = UnboundedContinuousTensorSpec()
+            if not isinstance(spec, TensorSpec):
+                raise RuntimeError(
+                    f"TDSequence.spec requires all specs to be valid TensorSpec objects. Got "
+                    f"{type(layer.spec)}"
+                )
+            kwargs[out_key] = spec
+        return CompositeSpec(**kwargs)
+
+    def make_functional_with_buffers(self, clone: bool = False):
+        """
+        Transforms a stateful module in a functional module and returns its parameters and buffers.
+        Unlike functorch.make_functional_with_buffers, this method supports lazy modules.
+
+        Returns:
+            A tuple of parameter and buffer tuples
+
+        Examples:
+            >>> from torchrl.data import NdUnboundedContinuousTensorSpec, TensorDict
+            >>> lazy_module1 = nn.LazyLinear(4)
+            >>> lazy_module2 = nn.LazyLinear(3)
+            >>> spec1 = NdUnboundedContinuousTensorSpec(18)
+            >>> spec2 = NdUnboundedContinuousTensorSpec(4)
+            >>> td_module1 = TDModule(spec=spec1, module=lazy_module1, in_keys=["some_input"], out_keys=["hidden"])
+            >>> td_module2 = TDModule(spec=spec2, module=lazy_module2, in_keys=["hidden"], out_keys=["some_output"])
+            >>> td_module = TDSequence(td_module1, td_module2)
+            >>> _, (params, buffers) = td_module.make_functional_with_buffers()
+            >>> print(params[0].shape) # the lazy module has been initialized
+            torch.Size([4, 18])
+            >>> print(td_module(
+            ...    TensorDict({'some_input': torch.randn(18)}, batch_size=[]),
+            ...    params=params,
+            ...    buffers=buffers))
+            TensorDict(
+                fields={
+                    some_input: Tensor(torch.Size([18]), dtype=torch.float32),
+                    hidden: Tensor(torch.Size([4]), dtype=torch.float32),
+                    some_output: Tensor(torch.Size([3]), dtype=torch.float32)},
+                batch_size=torch.Size([]),
+                device=cpu,
+                is_shared=False)
+
+        """
+        if clone:
+            self_copy = copy(self)
+            self_copy.module = copy(self_copy.module)
+        else:
+            self_copy = self
+        params = []
+        buffers = []
+        for i, module in enumerate(self.module):
+            self_copy.module[i], (
+                _params,
+                _buffers,
+            ) = module.make_functional_with_buffers()
+            params.extend(_params)
+            buffers.extend(_buffers)
+        return self_copy, (params, buffers)
+
+    def get_dist(
+        self,
+        tensordict: _TensorDict,
+        **kwargs,
+    ) -> Tuple[torch.distributions.Distribution, ...]:
+        L = len(self.module)
+
+        if isinstance(self.module[-1], ProbabilisticTensorDictModule):
+            if "params" in kwargs and "buffers" in kwargs:
+                param_splits = self._split_param(kwargs["params"], "params")
+                buffer_splits = self._split_param(kwargs["buffers"], "buffers")
+                kwargs_pruned = {
+                    key: item
+                    for key, item in kwargs.items()
+                    if key not in ("params", "buffers")
+                }
+                for i, (module, param, buffer) in enumerate(
+                    zip(self.module, param_splits, buffer_splits)
+                ):
+                    if "vmap" in kwargs_pruned and i > 0:
+                        # the tensordict is already expended
+                        kwargs_pruned["vmap"] = (0, 0, *(0,) * len(module.in_keys))
+                    if i < L - 1:
+                        tensordict = module(
+                            tensordict, params=param, buffers=buffer, **kwargs_pruned
+                        )
+                    else:
+                        out = module.get_dist(
+                            tensordict, params=param, buffers=buffer, **kwargs_pruned
+                        )
+
+            elif "params" in kwargs:
+                param_splits = self._split_param(kwargs["params"], "params")
+                kwargs_pruned = {
+                    key: item for key, item in kwargs.items() if key not in ("params",)
+                }
+                for i, (module, param) in enumerate(zip(self.module, param_splits)):
+                    if "vmap" in kwargs_pruned and i > 0:
+                        # the tensordict is already expended
+                        kwargs_pruned["vmap"] = (0, *(0,) * len(module.in_keys))
+                    if i < L - 1:
+                        tensordict = module(tensordict, params=param, **kwargs_pruned)
+                    else:
+                        out = module.get_dist(tensordict, params=param, **kwargs_pruned)
+
+            elif not len(kwargs):
+                for i, module in enumerate(self.module):
+                    if i < L - 1:
+                        tensordict = module(tensordict)
+                    else:
+                        out = module.get_dist(tensordict)
+            else:
+                raise RuntimeError(
+                    "TDSequence does not support keyword arguments other than 'params', 'buffers' and 'vmap'"
+                )
+
+            return out
+        else:
+            raise RuntimeError(
+                "Cannot call get_dist on a sequence of tensordicts that does not end with a probabilistic TensorDict"
+            )

--- a/torchrl/objectives/costs/impala.py
+++ b/torchrl/objectives/costs/impala.py
@@ -6,12 +6,12 @@
 import torch
 
 from torchrl.data.tensordict.tensordict import _TensorDict
-from torchrl.modules import ProbabilisticTDModule
+from torchrl.modules import ProbabilisticTensorDictModule
 from torchrl.objectives.returns.vtrace import vtrace
 
 
 class QValEstimator:
-    def __init__(self, value_model: ProbabilisticTDModule):
+    def __init__(self, value_model: ProbabilisticTensorDictModule):
         self.value_model = value_model
 
     @property

--- a/torchrl/objectives/costs/ppo.py
+++ b/torchrl/objectives/costs/ppo.py
@@ -11,7 +11,8 @@ from torch import distributions as d
 
 from torchrl.data.tensordict.tensordict import _TensorDict, TensorDict
 from torchrl.envs.utils import step_tensordict
-from torchrl.modules import ProbabilisticTDModule, TDModule
+from torchrl.modules import TDModule
+from ...modules.td_module import ProbabilisticTensorDictModule
 
 __all__ = ["PPOLoss", "ClipPPOLoss", "KLPENPPOLoss"]
 
@@ -35,8 +36,8 @@ class PPOLoss(_LossModule):
     https://arxiv.org/abs/1707.06347
 
     Args:
-        actor (Actor): policy operator.
-        critic (ProbabilisticTDModule): value operator.
+        actor (ProbabilisticTensorDictModule): policy operator.
+        critic (ValueOperator): value operator.
         advantage_key (str): the input tensordict key where the advantage is expected to be written.
             default: "advantage"
         entropy_bonus (bool): if True, an entropy bonus will be added to the loss to favour exploratory policies.
@@ -55,7 +56,7 @@ class PPOLoss(_LossModule):
 
     def __init__(
         self,
-        actor: ProbabilisticTDModule,
+        actor: ProbabilisticTensorDictModule,
         critic: TDModule,
         advantage_key: str = "advantage",
         advantage_diff_key: str = "value_error",
@@ -104,7 +105,7 @@ class PPOLoss(_LossModule):
         log_prob = dist.log_prob(action)
         log_prob = log_prob.unsqueeze(-1)
 
-        prev_log_prob = tensordict.get("action_log_prob")
+        prev_log_prob = tensordict.get("sample_log_prob")
         if prev_log_prob.requires_grad:
             raise RuntimeError("tensordict prev_log_prob requires grad.")
 
@@ -164,8 +165,8 @@ class ClipPPOLoss(PPOLoss):
         loss = -min( weight * advantage, min(max(weight, 1-eps), 1+eps) * advantage)
 
     Args:
-        actor (Actor): policy operator.
-        critic (ProbabilisticTDModule): value operator.
+        actor (ProbabilisticTensorDictModule): policy operator.
+        critic (ValueOperator): value operator.
         advantage_key (str): the input tensordict key where the advantage is expected to be written.
             default: "advantage"
         clip_epsilon (scalar): weight clipping threshold in the clipped PPO loss equation.
@@ -186,7 +187,7 @@ class ClipPPOLoss(PPOLoss):
 
     def __init__(
         self,
-        actor: ProbabilisticTDModule,
+        actor: ProbabilisticTensorDictModule,
         critic: TDModule,
         advantage_key: str = "advantage",
         clip_epsilon: float = 0.2,
@@ -268,8 +269,8 @@ class KLPENPPOLoss(PPOLoss):
     favouring a certain level of distancing between the two while still preventing them to be too much apart.
 
     Args:
-        actor (Actor): policy operator.
-        critic (ProbabilisticTDModule): value operator.
+        actor (ProbabilisticTensorDictModule): policy operator.
+        critic (ValueOperator): value operator.
         advantage_key (str): the input tensordict key where the advantage is expected to be written.
             default: "advantage"
         dtarg (scalar): target KL divergence.
@@ -295,7 +296,7 @@ class KLPENPPOLoss(PPOLoss):
 
     def __init__(
         self,
-        actor: ProbabilisticTDModule,
+        actor: ProbabilisticTensorDictModule,
         critic: TDModule,
         advantage_key="advantage",
         dtarg: float = 0.01,
@@ -348,23 +349,11 @@ class KLPENPPOLoss(PPOLoss):
         log_weight, dist = self._log_weight(tensordict)
         neg_loss = log_weight.exp() * advantage
 
-        tensordict_clone = tensordict.select(*self.actor.in_keys).clone()
-        params = []
-        out_key = self.actor.out_keys[0]
-        i = 0
-        while True:
-            key = f"{out_key}_dist_param_{i}"
-            if key in tensordict.keys():
-                params.append(tensordict.get(key))
-                i += 1
-            else:
-                break
+        tensordict_clone = tensordict.select(
+            *self.actor.in_keys, *self.actor.out_keys
+        ).clone()
 
-        if i == 0:
-            raise Exception(
-                "No parameter was found for the policy distribution. Consider building the policy with save_dist_params=True"
-            )
-        previous_dist, *_ = self.actor.build_dist_from_params(params)
+        previous_dist = self.actor.build_dist_from_params(tensordict_clone)
         current_dist, *_ = self.actor.get_dist(tensordict_clone)
         try:
             kl = torch.distributions.kl.kl_divergence(previous_dist, current_dist)

--- a/torchrl/objectives/costs/redq.py
+++ b/torchrl/objectives/costs/redq.py
@@ -113,7 +113,13 @@ class REDQLoss_deprecated(_LossModule):
             )
 
         if target_entropy == "auto":
-            target_entropy = -float(np.prod(actor_network.spec.shape))
+            if actor_network.spec is None:
+                raise RuntimeError(
+                    "Cannot infer the dimensionality of the action. Consider providing "
+                    "the target entropy explicitely or provide the spec of the "
+                    "action tensor in the actor network."
+                )
+            target_entropy = -float(np.prod(actor_network.spec["action"].shape))
         self.register_buffer(
             "target_entropy", torch.tensor(target_entropy, device=device)
         )
@@ -354,7 +360,13 @@ class REDQLoss(_LossModule):
             )
 
         if target_entropy == "auto":
-            target_entropy = -float(np.prod(actor_network.spec.shape))
+            if actor_network.spec is None:
+                raise RuntimeError(
+                    "Cannot infer the dimensionality of the action. Consider providing "
+                    "the target entropy explicitely or provide the spec of the "
+                    "action tensor in the actor network."
+                )
+            target_entropy = -float(np.prod(actor_network.spec["action"].shape))
         self.register_buffer(
             "target_entropy", torch.tensor(target_entropy, device=device)
         )

--- a/torchrl/objectives/costs/reinforce.py
+++ b/torchrl/objectives/costs/reinforce.py
@@ -4,15 +4,21 @@ import torch
 
 from torchrl.data.tensordict.tensordict import _TensorDict, TensorDict
 from torchrl.envs.utils import step_tensordict
-from torchrl.modules import ProbabilisticTDModule, TDModule
+from torchrl.modules import TDModule, ProbabilisticTensorDictModule
 from torchrl.objectives import distance_loss
 from torchrl.objectives.costs.common import _LossModule
 
 
 class ReinforceLoss(_LossModule):
+    """Reinforce loss module, as presented in
+    "Simple statistical gradient-following algorithms for connectionist reinforcement learning", Williams, 1992
+    https://doi.org/10.1007/BF00992696
+
+    """
+
     def __init__(
         self,
-        actor_network: ProbabilisticTDModule,
+        actor_network: ProbabilisticTensorDictModule,
         advantage_module: Callable[[_TensorDict], _TensorDict],
         critic: Optional[TDModule] = None,
         delay_value: bool = False,
@@ -72,7 +78,7 @@ class ReinforceLoss(_LossModule):
             buffers=self.actor_network_buffers,
         )
 
-        log_prob = tensordict.get("action_log_prob")
+        log_prob = tensordict.get("sample_log_prob")
         loss_actor = -log_prob * advantage.detach()
         loss_actor = loss_actor.mean()
         td_out = TensorDict({"loss_actor": loss_actor}, [])

--- a/torchrl/objectives/costs/sac.py
+++ b/torchrl/objectives/costs/sac.py
@@ -12,12 +12,12 @@ import torch
 from torch import Tensor
 
 from torchrl.data.tensordict.tensordict import _TensorDict, TensorDict
+from torchrl.modules import ProbabilisticActor
 from torchrl.modules import TDModule
 from torchrl.modules.td_module.actors import (
     ActorCriticWrapper,
 )
 from torchrl.objectives.costs.utils import distance_loss, next_state_value
-from ...modules.td_module.deprec import ProbabilisticActor_deprecated
 from .common import _LossModule
 
 __all__ = ["SACLoss"]
@@ -29,7 +29,7 @@ class SACLoss(_LossModule):
     Reinforcement Learning with a Stochastic Actor" https://arxiv.org/pdf/1801.01290.pdf
 
     Args:
-        actor_network (ProbabilisticActor_deprecated): stochastic actor
+        actor_network (ProbabilisticActor): stochastic actor
         qvalue_network (TDModule): Q(s, a) parametric model
         value_network (TDModule): V(s) parametric model\
         qvalue_network_bis (ProbabilisticTDModule, optional): if required, the
@@ -69,7 +69,7 @@ class SACLoss(_LossModule):
 
     def __init__(
         self,
-        actor_network: ProbabilisticActor_deprecated,
+        actor_network: ProbabilisticActor,
         qvalue_network: TDModule,
         value_network: TDModule,
         num_qvalue_nets: int = 2,

--- a/torchrl/objectives/costs/sac.py
+++ b/torchrl/objectives/costs/sac.py
@@ -15,9 +15,9 @@ from torchrl.data.tensordict.tensordict import _TensorDict, TensorDict
 from torchrl.modules import TDModule
 from torchrl.modules.td_module.actors import (
     ActorCriticWrapper,
-    ProbabilisticActor,
 )
 from torchrl.objectives.costs.utils import distance_loss, next_state_value
+from ...modules.td_module.deprec import ProbabilisticActor_deprecated
 from .common import _LossModule
 
 __all__ = ["SACLoss"]
@@ -29,7 +29,7 @@ class SACLoss(_LossModule):
     Reinforcement Learning with a Stochastic Actor" https://arxiv.org/pdf/1801.01290.pdf
 
     Args:
-        actor_network (ProbabilisticActor): stochastic actor
+        actor_network (ProbabilisticActor_deprecated): stochastic actor
         qvalue_network (TDModule): Q(s, a) parametric model
         value_network (TDModule): V(s) parametric model\
         qvalue_network_bis (ProbabilisticTDModule, optional): if required, the
@@ -69,7 +69,7 @@ class SACLoss(_LossModule):
 
     def __init__(
         self,
-        actor_network: ProbabilisticActor,
+        actor_network: ProbabilisticActor_deprecated,
         qvalue_network: TDModule,
         value_network: TDModule,
         num_qvalue_nets: int = 2,

--- a/torchrl/objectives/costs/sac.py
+++ b/torchrl/objectives/costs/sac.py
@@ -139,7 +139,13 @@ class SACLoss(_LossModule):
             )
 
         if target_entropy == "auto":
-            target_entropy = -float(np.prod(actor_network.spec.shape))
+            if actor_network.spec is None:
+                raise RuntimeError(
+                    "Cannot infer the dimensionality of the action. Consider providing "
+                    "the target entropy explicitely or provide the spec of the "
+                    "action tensor in the actor network."
+                )
+            target_entropy = -float(np.prod(actor_network.spec["action"].shape))
         self.register_buffer(
             "target_entropy", torch.tensor(target_entropy, device=device)
         )

--- a/torchrl/trainers/helpers/collectors.py
+++ b/torchrl/trainers/helpers/collectors.py
@@ -420,7 +420,7 @@ def _parser_collector_args(parser: ArgumentParser) -> ArgumentParser:
         "--exploration-mode",
         type=str,
         default=None,
-        help="exploration mode of the data collector. If gSDE is being used, this should be set to `'net_output'`.",
+        help="exploration mode of the data collector.",
     )
     parser.add_argument(
         "--async_collection",

--- a/torchrl/trainers/helpers/collectors.py
+++ b/torchrl/trainers/helpers/collectors.py
@@ -26,7 +26,7 @@ __all__ = [
 ]
 
 from torchrl.envs.common import _EnvClass
-from torchrl.modules import ProbabilisticTDModule, TDModuleWrapper
+from torchrl.modules import TDModuleWrapper, ProbabilisticTensorDictModule
 
 
 def sync_async_collector(
@@ -240,7 +240,7 @@ def _make_collector(
 
 def make_collector_offpolicy(
     make_env: Callable[[], _EnvClass],
-    actor_model_explore: Union[TDModuleWrapper, ProbabilisticTDModule],
+    actor_model_explore: Union[TDModuleWrapper, ProbabilisticTensorDictModule],
     args: Namespace,
     make_env_kwargs=None,
 ) -> _DataCollector:
@@ -303,7 +303,7 @@ def make_collector_offpolicy(
 
 def make_collector_onpolicy(
     make_env: Callable[[], _EnvClass],
-    actor_model_explore: Union[TDModuleWrapper, ProbabilisticTDModule],
+    actor_model_explore: Union[TDModuleWrapper, ProbabilisticTensorDictModule],
     args: Namespace,
     make_env_kwargs=None,
 ) -> _DataCollector:

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -200,20 +200,11 @@ def transformed_env_constructor(
                     CatFrames(N=args.catframes, keys=[out_key], cat_dim=-1)
                 )
 
-            if hasattr(args, "gSDE") and args.gSDE:
-                state_dim = env.observation_spec[out_key].shape[-1]
-                env.append_transform(
-                    gSDENoise(
-                        action_dim=env.action_spec.shape[-1],
-                        observation_key=out_key,
-                        state_dim=state_dim,
-                    )
-                )
-
         else:
             env.append_transform(DoubleToFloat(keys=double_to_float_list))
-            if hasattr(args, "gSDE") and args.gSDE:
-                raise RuntimeError("gSDE not compatible with from_pixels=True")
+
+        if hasattr(args, "gSDE") and args.gSDE:
+            env.append_transform(gSDENoise())
 
         env.append_transform(FiniteTensorDictCheck())
         return env

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -239,7 +239,7 @@ def make_ddpg_actor(
             fields={
                 done: Tensor(torch.Size([1]), dtype=torch.bool),
                 observation_vector: Tensor(torch.Size([17]), dtype=torch.float32),
-                net_output: Tensor(torch.Size([6]), dtype=torch.float32),
+                param: Tensor(torch.Size([6]), dtype=torch.float32),
                 action: Tensor(torch.Size([6]), dtype=torch.float32)},
             batch_size=torch.Size([]),
             device=cpu,
@@ -249,7 +249,7 @@ def make_ddpg_actor(
             fields={
                 done: Tensor(torch.Size([1]), dtype=torch.bool),
                 observation_vector: Tensor(torch.Size([17]), dtype=torch.float32),
-                net_output: Tensor(torch.Size([6]), dtype=torch.float32),
+                param: Tensor(torch.Size([6]), dtype=torch.float32),
                 action: Tensor(torch.Size([6]), dtype=torch.float32),
                 state_action_value: Tensor(torch.Size([1]), dtype=torch.float32)},
             batch_size=torch.Size([]),
@@ -287,13 +287,13 @@ def make_ddpg_actor(
     else:
         in_keys = ["observation_vector"]
         actor_net = DdpgMlpActor(**actor_net_default_kwargs)
-    actor_module = TDModule(actor_net, in_keys=in_keys, out_keys=["net_output"])
+    actor_module = TDModule(actor_net, in_keys=in_keys, out_keys=["param"])
 
     # We use a ProbabilisticActor to make sure that we map the network output to the right space using a TanhDelta
     # distribution.
     actor = ProbabilisticActor(
         actor_module,
-        dist_param_keys=["net_output"],
+        dist_param_keys=["param"],
         spec=env_specs["action_spec"],
         safe=True,
         distribution_class=TanhDelta,

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -9,7 +9,7 @@ from typing import Optional, Sequence
 import torch
 from torch import nn
 
-from torchrl.data import DEVICE_TYPING
+from torchrl.data import DEVICE_TYPING, CompositeSpec
 from torchrl.envs.common import _EnvClass
 from torchrl.modules import (
     ActorValueOperator,
@@ -177,7 +177,7 @@ def make_dqn_actor(
 
     model = actor_class(
         module=net,
-        spec=action_spec,
+        spec=CompositeSpec(action=action_spec),
         in_keys=[in_key],
         safe=True,
         **actor_kwargs,
@@ -292,9 +292,9 @@ def make_ddpg_actor(
     # We use a ProbabilisticActor to make sure that we map the network output to the right space using a TanhDelta
     # distribution.
     actor = ProbabilisticActor(
-        actor_module,
+        module=actor_module,
         dist_param_keys=["param"],
-        spec=env_specs["action_spec"],
+        spec=CompositeSpec(action=env_specs["action_spec"]),
         safe=True,
         distribution_class=TanhDelta,
         distribution_kwargs={
@@ -551,7 +551,7 @@ def make_ppo_model(
             )
 
         policy_operator = ProbabilisticActor(
-            spec=action_spec,
+            spec=CompositeSpec(action=action_spec),
             module=actor_module,
             dist_param_keys=["loc", "scale"],
             default_interaction_mode="random",


### PR DESCRIPTION
This PR refactors from the ground up the `ProbabilisticTDModule` class, which is at the base of many RL policies.
The former class was messy, with a lot of ad-hoc rules hard to understand even for the eng that coded them (hm!)

In this PR:
- We propose a new `ProbabilisticTensorDictModule` and `ProbabilisticActor` class
- We refactor gSDE to fit the new logic (cleaner now)
- We make the test abide by the new rules
- We solve a bug in the lazy `_CustomOpTensorDict` classes
- `spec` is now completely optional for all `TDModule` classes
- the `safe` flag for TDModules is restricted to the `"action"` key. We can think later on how to make this more general if needed
- casting of the tensordicts from device to device during rollouts in the data collectors are not done inplace anymore, to accomodate for the `gSDE` noise shape change.

Ultimately, this PR will allow us to use gSDE and other exploration more efficiently, for DDPG for instance. IMO the object responsibilities are clearer.

The new `ProbabilisticTensorDictModule` class constructor wraps a regular `TDModule` and uses it as a parameter generator:
```python
>>> from torchrl.modules.td_module import ProbabilisticTensorDictModule
>>> from torchrl.data import TensorDict, NdUnboundedContinuousTensorSpec
>>> from torchrl.modules import  TanhNormal, NormalParamWrapper
>>> import functorch, torch
>>> td = TensorDict({"input": torch.randn(3, 4)}, [3,])
>>> spec = NdUnboundedContinuousTensorSpec(4)
>>> net = NormalParamWrapper(torch.nn.Linear(4, 8))
>>> fnet, params, buffers = functorch.make_functional_with_buffers(net)
>>> module = TDModule(fnet, in_keys=["input"], out_keys=["loc", "scale"])
>>> td_module = ProbabilisticTensorDictModule(
...    module=module,
...    spec=spec,
...    dist_param_keys=["loc", "scale"],
...    out_key_sample=["action"],
...    distribution_class=TanhNormal,
...    return_log_prob=True,
...    )
>>> _ = td_module(td, params=params, buffers=buffers)
>>> print(td)
```
results in 
```
        TensorDict(
            fields={
                input: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                loc: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                scale: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                action: Tensor(torch.Size([3, 4]), dtype=torch.float32),
                sample_log_prob: Tensor(torch.Size([3, 1]), dtype=torch.float32)},
            batch_size=torch.Size([3]),
            device=cpu,
            is_shared=False)
```

of course you can `vmap`:
```python
>>> # In the vmap case, the tensordict is again expended to match the batch:
>>> params = tuple(p.expand(4, *p.shape).contiguous().normal_() for p in params)
>>> buffers = tuple(b.expand(4, *b.shape).contiguous().normal_() for p in buffers)
>>> td_vmap = td_module(td, params=params, buffers=buffers, vmap=True)
>>> print(td_vmap)
```

Result:
```
        TensorDict(
            fields={
                input: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                hidden: Tensor(torch.Size([4, 3, 8]), dtype=torch.float32),
                loc: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                scale: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                action: Tensor(torch.Size([4, 3, 4]), dtype=torch.float32),
                sample_log_prob: Tensor(torch.Size([4, 3, 1]), dtype=torch.float32)},
            batch_size=torch.Size([4, 3]),
            device=cpu,
            is_shared=False)
```

Essentially, we delegate to two different objects the responsibility for computing distribution parameters and building/sampling from that distribution.

The `gSDE` use case is now much clearer: before, it was hard to build a probabilistic actor with gSDE as it had to "ignore" the sampling step (since it's computed by the network itself).
Now the network has the signature 
```python
def forward(self, state, noise):
     ...
     return loc, scale, action, noise
```
and the `TDModule` "knows" what to expect.
The `ProbabilisticActor` then sees that the TDModule has `"action"` in its out keys, and hence knows it should not sample it. Still, you can access the distribution through `actor.get_dist(tensordict)`.
 
Example for gSDE [here](https://github.com/facebookresearch/rl/blob/2490906c91b948202ce7dd557fbd10d1db9df6ea/test/test_exploration.py#L92-L157)


@shagunsodhani @Benjamin-eecs 