### PR TITLE
gSDE: lazy state-dependent initialization

### DIFF
--- a/examples/ddpg/configs/humanoid.txt
+++ b/examples/ddpg/configs/humanoid.txt
@@ -3,12 +3,17 @@ env_task=walk
 env_library=dm_control
 async_collection
 record_video
-normalize_rewards_online
 prb
-multi_step
-exp_name=humanoid_stats_wd
-frames_per_batch=256
+normalize_rewards_online
+normalize_rewards_online_scale=10
+exp_name=humanoid
+
+num_workers=8
+env_per_collector=2
+collector_devices=cuda:1 cuda:2 cuda:3 cuda:4
+
 frame_skip=2
-optim_steps_per_batch=4
-batch_size=64
+frames_per_batch=500
+optim_steps_per_batch=80
+batch_size=128
 total_frames=5000000

--- a/examples/ddpg/configs/humanoid.txt
+++ b/examples/ddpg/configs/humanoid.txt
@@ -10,7 +10,6 @@ exp_name=humanoid
 
 num_workers=8
 env_per_collector=2
-collector_devices cuda:1 cuda:2 cuda:3 cuda:4
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/ddpg/configs/humanoid.txt
+++ b/examples/ddpg/configs/humanoid.txt
@@ -10,7 +10,7 @@ exp_name=humanoid
 
 num_workers=8
 env_per_collector=2
-collector_devices=cuda:1 cuda:2 cuda:3 cuda:4
+collector_devices cuda:1 cuda:2 cuda:3 cuda:4
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/ddpg/configs/humanoid_pixels.txt
+++ b/examples/ddpg/configs/humanoid_pixels.txt
@@ -8,9 +8,8 @@ normalize_rewards_online
 normalize_rewards_online_scale=10
 exp_name=humanoid
 
-num_workers=8
-env_per_collector=2
-collector_devices=cuda:1 cuda:2 cuda:3 cuda:4
+num_workers=32
+env_per_collector=8
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/ddpg/configs/humanoid_pixels.txt
+++ b/examples/ddpg/configs/humanoid_pixels.txt
@@ -7,7 +7,6 @@ prb
 normalize_rewards_online
 normalize_rewards_online_scale=10
 exp_name=humanoid
-tanh_loc
 
 num_workers=8
 env_per_collector=2
@@ -18,3 +17,6 @@ frames_per_batch=500
 optim_steps_per_batch=80
 batch_size=128
 total_frames=5000000
+
+from_pixels
+no_norm_stats

--- a/examples/ddpg/configs/humanoid_pixels.txt
+++ b/examples/ddpg/configs/humanoid_pixels.txt
@@ -19,4 +19,3 @@ batch_size=128
 total_frames=5000000
 
 from_pixels
-no_norm_stats

--- a/examples/ddpg/configs/humanoid_pixels.txt
+++ b/examples/ddpg/configs/humanoid_pixels.txt
@@ -19,3 +19,6 @@ batch_size=128
 total_frames=5000000
 
 from_pixels
+activation=elu
+lr=0.001
+weight_decay=2e-5

--- a/examples/ddpg/ddpg.py
+++ b/examples/ddpg/ddpg.py
@@ -100,7 +100,21 @@ def main(args):
     writer = SummaryWriter(f"ddpg_logging/{exp_name}")
     video_tag = exp_name if args.record_video else ""
 
-    proof_env = transformed_env_constructor(args=args, use_env_creator=False)()
+    stats = None
+    if not args.vecnorm and args.norm_stats:
+        proof_env = transformed_env_constructor(args=args, use_env_creator=False)()
+        stats = get_stats_random_rollout(
+            args, proof_env, key="next_pixels" if args.from_pixels else None
+        )
+        # make sure proof_env is closed
+        proof_env.close()
+    elif args.from_pixels:
+        stats = {"loc": 0.5, "scale": 0.5}
+    proof_env = transformed_env_constructor(
+        args=args, use_env_creator=False, stats=stats
+    )()
+    create_env_fn = parallel_env_constructor(args=args, stats=stats)
+
     model = make_ddpg_actor(
         proof_env,
         args,
@@ -117,14 +131,7 @@ def main(args):
     if device == torch.device("cpu"):
         # mostly for debugging
         actor_model_explore.share_memory()
-
-    stats = None
-    if not args.vecnorm and args.norm_stats:
-        stats = get_stats_random_rollout(args, proof_env)
-    # make sure proof_env is closed
     proof_env.close()
-
-    create_env_fn = parallel_env_constructor(args=args, stats=stats)
 
     collector = make_collector_offpolicy(
         make_env=create_env_fn,

--- a/examples/redq/configs/humanoid.txt
+++ b/examples/redq/configs/humanoid.txt
@@ -11,7 +11,6 @@ tanh_loc
 
 num_workers=8
 env_per_collector=2
-collector_devices cuda:1 cuda:2 cuda:3 cuda:4
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/redq/configs/humanoid.txt
+++ b/examples/redq/configs/humanoid.txt
@@ -11,7 +11,7 @@ tanh_loc
 
 num_workers=8
 env_per_collector=2
-collector_devices=cuda:1 cuda:2 cuda:3 cuda:4
+collector_devices cuda:1 cuda:2 cuda:3 cuda:4
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/sac/configs/humanoid.txt
+++ b/examples/sac/configs/humanoid.txt
@@ -11,7 +11,6 @@ tanh_loc
 
 num_workers=8
 env_per_collector=2
-collector_devices cuda:1 cuda:2 cuda:3 cuda:4
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/sac/configs/humanoid.txt
+++ b/examples/sac/configs/humanoid.txt
@@ -11,7 +11,7 @@ tanh_loc
 
 num_workers=8
 env_per_collector=2
-collector_devices=cuda:1 cuda:2 cuda:3 cuda:4
+collector_devices cuda:1 cuda:2 cuda:3 cuda:4
 
 frame_skip=2
 frames_per_batch=500

--- a/examples/sac/configs/humanoid.txt
+++ b/examples/sac/configs/humanoid.txt
@@ -3,14 +3,18 @@ env_task=walk
 env_library=dm_control
 async_collection
 record_video
-frame_skip=2
-frames_per_batch=256
-optim_steps_per_batch=4
-batch_size=64
 prb
+normalize_rewards_online
+normalize_rewards_online_scale=10
 exp_name=humanoid
 tanh_loc
-total_frames=5000000
+
 num_workers=8
-env_per_collector=8
-collector_devices=cuda:1
+env_per_collector=2
+collector_devices=cuda:1 cuda:2 cuda:3 cuda:4
+
+frame_skip=2
+frames_per_batch=500
+optim_steps_per_batch=80
+batch_size=128
+total_frames=5000000

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -165,6 +165,35 @@ def test_gsde(
                 torch.testing.assert_allclose(action1, action2)
 
 
+@pytest.mark.parametrize(
+    "state_dim",
+    [
+        (5,),
+        (12,),
+        (12, 3),
+    ],
+)
+@pytest.mark.parametrize("action_dim", [5, 12])
+@pytest.mark.parametrize("mean", [0, -2])
+@pytest.mark.parametrize("std", [1, 2])
+@pytest.mark.parametrize("sigma_init", [None, 1.5, 3])
+@pytest.mark.parametrize("learn_sigma", [False, True])
+@pytest.mark.parametrize("device", get_available_devices())
+def test_gsde_init(sigma_init, state_dim, action_dim, mean, std, device, learn_sigma):
+    torch.manual_seed(0)
+    state = torch.randn(100000, *state_dim, device=device) * std + mean
+    action = torch.randn(100000, *state_dim[:-1], action_dim, device=device)
+    # lazy
+    gsde_lazy = LazygSDEModule(sigma_init=sigma_init, learn_sigma=learn_sigma)
+    _eps = torch.randn(100000, *state_dim[:-1], action_dim, state_dim[-1])
+    with set_exploration_mode("random"):
+        mu, sigma, action_out, _eps = gsde_lazy(action, state, _eps)
+    sigma_init = sigma_init if sigma_init else 1.0
+    assert (
+        abs(sigma_init - sigma.mean()) < 0.3
+    ), f"failed: mean={mean}, std={std}, sigma_init={sigma_init}, actual: {sigma.mean()}"
+
+
 if __name__ == "__main__":
     args, unknown = argparse.ArgumentParser().parse_known_args()
     pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -818,13 +818,13 @@ class ObservationNorm(ObservationTransform):
 
     def _apply(self, obs: torch.Tensor) -> torch.Tensor:
         if self.standard_normal:
-            # converts the transform (x-m)/sqrt(v) to x * s + loc
-            scale = self.scale.reciprocal()
-            loc = -self.loc * scale
+            loc = self.loc
+            scale = self.scale
+            return (obs - loc) / scale
         else:
             scale = self.scale
             loc = self.loc
-        return obs * scale + loc
+            return obs * scale + loc
 
     def transform_observation_spec(self, observation_spec: TensorSpec) -> TensorSpec:
         if isinstance(observation_spec, CompositeSpec):

--- a/torchrl/modules/models/exploration.py
+++ b/torchrl/modules/models/exploration.py
@@ -230,33 +230,22 @@ def reset_noise(layer: nn.Module) -> None:
 
 
 class gSDEModule(nn.Module):
-    """A gSDE exploration wrapper as presented in "Smooth Exploration for
+    """A gSDE exploration module as presented in "Smooth Exploration for
     Robotic Reinforcement Learning" by Antonin Raffin, Jens Kober,
     Freek Stulp (https://arxiv.org/abs/2005.05719)
 
-    gSDEWrapper encapsulates nn.Module that outputs the average of a
-    normal distribution and adds a state-dependent exploration noise to it.
-    It outputs the mean, scale (standard deviation) of the normal
-    distribution as well as the chosen action.
-
-    For now, only vector states are considered, but the distribution can
-    read other inputs (e.g. hidden states etc.)
+    gSDEModule adds a state-dependent exploration noise to an input action.
+    It also outputs the mean, scale (standard deviation) of the normal
+    distribution, as well as the Gaussian noise used.
 
     The noise input should be reset through a `torchrl.envs.transforms.gSDENoise`
-    instance: each time the environment is reset, the gSDENoise will be erased
-    and resampled inside this wrapper.
-    Finally, a regular normal distribution should be used to sample the
-    actions, the `ProbabilisticTensorDictModule` should be created
-    in safe mode (in order for the action to be clipped in the desired
-    range) and its input keys should include `"_eps_gSDE"` which is the
-    default gSDE noise key:
+    instance: each time the environment is reset, the input noise will be set to
+    zero by the environment transform, indicating to gSDEModule that it has to be resampled.
+    This scheme allows us to have the environemt tell the module to resample a
+    noise only the latter knows the shape of.
 
-        >>> actor = ProbabilisticActor(
-        ...     TDModule(wrapped_module, in_keys=["observation"], out_keys=["loc", "scale", "action", "_eps_gSDE"]),
-        ...     dist_param_keys=["loc", "scale"],
-        ...     spec=spec,
-        ...     distribution_class=IndependentNormal,  # or TanhNormal, etc.
-        ...     safe=True)
+    A variable transform function can also be provided to map the noicy action
+    to the desired space (e.g. a SafeTanhTransform or similar).
 
     Args:
         policy_model (nn.Module): a model that reads observations and
@@ -272,16 +261,41 @@ class gSDEModule(nn.Module):
             to the sampled action.
 
     Examples:
+        >>> from torchrl.modules import TDModule, TDSequence, ProbabilisticActor, TanhNormal
+        >>> from torchrl.data import TensorDict
         >>> batch, state_dim, action_dim = 3, 7, 5
         >>> model = nn.Linear(state_dim, action_dim)
-        >>> wrapped_model = gSDEWrapper(model, action_dim=action_dim,
-        ...     state_dim=state_dim)
-        >>> state = torch.randn(batch, state_dim)
-        >>> eps_gSDE = torch.randn(batch, action_dim, state_dim)
-        >>> # the module takes inputs (state, *additional_vectors, noise_param)
-        >>> mu, sigma, action, noise = wrapped_model(state, eps_gSDE)
-        >>> print(mu.shape, sigma.shape, action.shape)
-        torch.Size([3, 5]) torch.Size([3, 5]) torch.Size([3, 5])
+        >>> deterministic_policy = TDModule(model, in_keys=["obs"], out_keys=["action"])
+        >>> stochatstic_part = TDModule(
+        ...     gSDEModule(action_dim, state_dim),
+        ...     in_keys=["action", "obs", "_eps_gSDE"],
+        ...     out_keys=["loc", "scale", "action", "_eps_gSDE"])
+        >>> stochatstic_part = ProbabilisticActor(stochatstic_part,
+        ...      dist_param_keys=["loc", "scale"],
+        ...      distribution_class=TanhNormal)
+        >>> stochatstic_policy = TDSequence(deterministic_policy, stochatstic_part)
+        >>> tensordict = TensorDict({'obs': torch.randn(state_dim), '_epx_gSDE': torch.zeros(1)}, [])
+        >>> _ = stochatstic_policy(tensordict)
+        >>> print(tensordict)
+        TensorDict(
+            fields={
+                obs: Tensor(torch.Size([7]), dtype=torch.float32),
+                _epx_gSDE: Tensor(torch.Size([1]), dtype=torch.float32),
+                action: Tensor(torch.Size([5]), dtype=torch.float32),
+                loc: Tensor(torch.Size([5]), dtype=torch.float32),
+                scale: Tensor(torch.Size([5]), dtype=torch.float32),
+                _eps_gSDE: Tensor(torch.Size([5, 7]), dtype=torch.float32)},
+            batch_size=torch.Size([]),
+            device=cpu,
+            is_shared=False)
+        >>> action_first_call = tensordict.get("action").clone()
+        >>> dist, *_ = stochatstic_policy.get_dist(tensordict)
+        >>> print(dist)
+        TanhNormal(loc: torch.Size([5]), scale: torch.Size([5]))
+        >>> _ = stochatstic_policy(tensordict)
+        >>> action_second_call = tensordict.get("action").clone()
+        >>> assert (action_second_call == action_first_call).all()  # actions are the same
+        >>> assert (action_first_call != dist.base_dist.base_dist.loc).all()  # actions are truly stochastic
     """
 
     def __init__(
@@ -322,11 +336,8 @@ class gSDEModule(nn.Module):
     @property
     def sigma(self):
         if self.learn_sigma:
-            sigma = (
-                torch.nn.functional.softplus(self.log_sigma + self.sigma_init)
-                + self.scale_min
-            )
-            return sigma
+            sigma = torch.nn.functional.softplus(self.log_sigma)
+            return sigma.clamp_min(self.scale_min)
         else:
             return self._sigma.clamp_min(self.scale_min)
 
@@ -384,6 +395,15 @@ class gSDEModule(nn.Module):
 
 
 class LazygSDEModule(LazyModuleMixin, gSDEModule):
+    """Lazy gSDE Module.
+    This module behaves exactly as gSDEModule except that it does not require the
+    user to specify the action and state dimension.
+    If the input state is multi-dimensional (i.e. more than one state is provided), the
+    sigma value is initialized such that the resulting variance will match `sigma_init`
+    (or 1 if no `sigma_init` value is provided).
+
+    """
+
     cls_to_become = gSDEModule
     log_sigma: UninitializedParameter
     _sigma: UninitializedBuffer
@@ -392,7 +412,7 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
     def __init__(
         self,
         sigma_init: float = None,
-        scale_min: float = 0.1,
+        scale_min: float = 0.01,
         scale_max: float = 10.0,
         learn_sigma: bool = True,
         transform: Optional[d.Transform] = None,
@@ -427,35 +447,30 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
             action_dim = mu.shape[-1]
             state_dim = state.shape[-1]
             with torch.no_grad():
-                if self._sigma_init is None:
-                    if state.ndimension() > 2:
-                        state_flatten = state.flatten(0, -2)
-                        state_flatten_var = state_flatten.std(dim=0)
-                    elif state.ndimension() == 1:
-                        state_flatten_var = torch.ones(1).to(state.device)
-                    else:
-                        state_flatten_var = state.std(dim=0)
+                if state.ndimension() > 2:
+                    state = state.flatten(0, -2).squeeze(0)
+                if state.ndimension() == 1:
+                    state_flatten_var = torch.ones(1).to(state.device)
                 else:
-                    state_flatten_var = torch.tensor(
-                        self._sigma_init, device=state.device
-                    )
+                    state_flatten_var = state.pow(2).mean(dim=0).reciprocal()
 
                 self.sigma_init.materialize(state_flatten_var.shape)
                 if self.learn_sigma:
                     if self._sigma_init is None:
                         state_flatten_var.clamp_min_(self.scale_min)
                         self.sigma_init.data.copy_(
-                            inv_softplus(
-                                (
-                                    (state_flatten_var - self.scale_min) / state_dim
-                                ).sqrt()
-                            )
+                            inv_softplus((state_flatten_var / state_dim).sqrt())
                         )
                     else:
-                        self.sigma_init.data.fill_(inv_softplus(self._sigma_init))
+                        self.sigma_init.data.copy_(
+                            inv_softplus(
+                                self._sigma_init
+                                * (state_flatten_var / state_dim).sqrt()
+                            )
+                        )
 
                     self.log_sigma.materialize((action_dim, state_dim))
-                    self.log_sigma.data.copy_(self.sigma_init.expand_as(self._sigma))
+                    self.log_sigma.data.copy_(self.sigma_init.expand_as(self.log_sigma))
 
                 else:
                     if self._sigma_init is None:
@@ -463,6 +478,8 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
                             (state_flatten_var / state_dim).sqrt()
                         )
                     else:
-                        self.sigma_init.data.fill_(self._sigma_init)
+                        self.sigma_init.data.copy_(
+                            (state_flatten_var / state_dim).sqrt() * self._sigma_init
+                        )
                     self._sigma.materialize((action_dim, state_dim))
                     self._sigma.data.copy_(self.sigma_init.expand_as(self._sigma))

--- a/torchrl/modules/models/exploration.py
+++ b/torchrl/modules/models/exploration.py
@@ -426,7 +426,10 @@ class LazygSDEModule(LazyModuleMixin, gSDEModule):
             state_dim = state.shape[-1]
             with torch.no_grad():
                 if self._sigma_init is None:
-                    state_flatten = state.flatten(0, -2)
+                    if state.ndimension() > 2:
+                        state_flatten = state.flatten(0, -2)
+                    else:
+                        state_flatten = state
                     state_flatten_var = state_flatten.var(dim=0)
                 if self.learn_sigma:
                     if self._sigma_init is None:

--- a/torchrl/modules/utils/mappings.py
+++ b/torchrl/modules/utils/mappings.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Callable
+from typing import Callable, Union
 
 import torch
 from torch import nn
@@ -11,12 +11,19 @@ from torch import nn
 __all__ = ["mappings", "inv_softplus", "biased_softplus"]
 
 
-def inv_softplus(bias: float):
+def inv_softplus(bias: Union[float, torch.Tensor]) -> Union[float, torch.Tensor]:
     """
     inverse softplus function.
 
     """
-    return torch.tensor(bias).expm1().clamp_min(1e-6).log().item()
+    is_tensor = True
+    if not isinstance(bias, torch.Tensor):
+        is_tensor = False
+        bias = torch.tensor(bias)
+    out = bias.expm1().clamp_min(1e-6).log()
+    if not is_tensor and out.numel() == 1:
+        return out.item()
+    return out
 
 
 class biased_softplus(nn.Module):

--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -149,9 +149,12 @@ def transformed_env_constructor(
             env.append_transform(Resize(84, 84))
             env.append_transform(GrayScale())
             env.append_transform(CatFrames(keys=["next_pixels"]))
-            env.append_transform(
-                ObservationNorm(loc=-1.0, scale=2.0, keys=["next_pixels"])
-            )
+            if stats is None:
+                obs_stats = {"loc": 0.0, "scale": 1.0}
+            else:
+                obs_stats = stats
+            obs_stats["standard_normal"] = True
+            env.append_transform(ObservationNorm(**obs_stats, keys=["next_pixels"]))
         if norm_rewards:
             reward_scaling = 1.0
             reward_loc = 0.0

--- a/torchrl/trainers/helpers/models.py
+++ b/torchrl/trainers/helpers/models.py
@@ -188,8 +188,7 @@ def make_dqn_actor(
 
     # init
     with torch.no_grad():
-        proof_environment.reset()
-        td = proof_environment.current_tensordict
+        td = proof_environment.rollout(n_steps=1000)
         model(td.to(device))
     return model
 
@@ -382,8 +381,8 @@ def make_ddpg_actor(
 
     # init
     with torch.no_grad(), set_exploration_mode("random"):
-        proof_environment.reset()
-        td = proof_environment.current_tensordict.to(device)
+        td = proof_environment.rollout(n_steps=1000)
+        td = td.to(device)
         module[0](td)
         module[1](td)
 
@@ -682,8 +681,7 @@ def make_ppo_model(
         actor_value = ActorCriticWrapper(policy_po, value_po).to(device)
 
     with torch.no_grad(), set_exploration_mode("random"):
-        proof_environment.reset()
-        td = proof_environment.current_tensordict
+        td = proof_environment.rollout(n_steps=1000)
         td_device = td.to(device)
         td_device = td_device.unsqueeze(0)
         td_device = actor_value(td_device)  # for init


### PR DESCRIPTION
We implement `lazygSDEModule`, a lazy implementation of gSDE that does not require to know the state dimension in advance.
This is advantageous as the state dimension can be hard to forecast (e.g. if it's a flattened tensor coming from a CNN).
We add tests for this lazy version of gSDE, that assess whether the output standard deviation matches the required one.
The docstrings of the classes have also been updated.