### PR TITLE
Refactoring environment device setting/casting

### DIFF
--- a/examples/ddpg/ddpg.py
+++ b/examples/ddpg/ddpg.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime
 
 from torchrl.envs import ParallelEnv
+from torchrl.envs.utils import set_exploration_mode
 
 try:
     import configargparse as argparse
@@ -113,7 +114,6 @@ def main(args):
     proof_env = transformed_env_constructor(
         args=args, use_env_creator=False, stats=stats
     )()
-    create_env_fn = parallel_env_constructor(args=args, stats=stats)
 
     model = make_ddpg_actor(
         proof_env,
@@ -131,12 +131,31 @@ def main(args):
     if device == torch.device("cpu"):
         # mostly for debugging
         actor_model_explore.share_memory()
+    if args.gSDE:
+        if args.gSDE:
+            with torch.no_grad(), set_exploration_mode("random"):
+                # get dimensions to build the parallel env
+                proof_td = actor_model_explore(proof_env.reset().to(device))
+        action_dim_gsde, state_dim_gsde = proof_td.get("_eps_gSDE").shape[-2:]
+        del proof_td
+    else:
+        action_dim_gsde, state_dim_gsde = None, None
     proof_env.close()
+    create_env_fn = parallel_env_constructor(
+        args=args,
+        stats=stats,
+        action_dim_gsde=action_dim_gsde,
+        state_dim_gsde=state_dim_gsde,
+    )
 
     collector = make_collector_offpolicy(
         make_env=create_env_fn,
         actor_model_explore=actor_model_explore,
         args=args,
+        # make_env_kwargs=[
+        #     {"device": device} if device >= 0 else {}
+        #     for device in args.env_rendering_devices
+        # ],
     )
 
     replay_buffer = make_replay_buffer(device, args)

--- a/examples/dqn/dqn.py
+++ b/examples/dqn/dqn.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime
 
 from torchrl.envs import ParallelEnv
+from torchrl.envs.utils import set_exploration_mode
 
 try:
     import configargparse as argparse
@@ -103,7 +104,6 @@ def main(args):
     proof_env = transformed_env_constructor(
         args=args, use_env_creator=False, stats=stats
     )()
-    create_env_fn = parallel_env_constructor(args=args, stats=stats)
     model = make_dqn_actor(
         proof_environment=proof_env,
         args=args,
@@ -114,12 +114,30 @@ def main(args):
     model_explore = EGreedyWrapper(model, annealing_num_steps=args.annealing_frames).to(
         device
     )
+    if args.gSDE:
+        with torch.no_grad(), set_exploration_mode("random"):
+            # get dimensions to build the parallel env
+            proof_td = model(proof_env.reset().to(device))
+        action_dim_gsde, state_dim_gsde = proof_td.get("_eps_gSDE").shape[-2:]
+        del proof_td
+    else:
+        action_dim_gsde, state_dim_gsde = None, None
     proof_env.close()
+    create_env_fn = parallel_env_constructor(
+        args=args,
+        stats=stats,
+        action_dim_gsde=action_dim_gsde,
+        state_dim_gsde=state_dim_gsde,
+    )
 
     collector = make_collector_offpolicy(
         make_env=create_env_fn,
         actor_model_explore=model_explore,
         args=args,
+        # make_env_kwargs=[
+        #     {"device": device} if device >= 0 else {}
+        #     for device in args.env_rendering_devices
+        # ],
     )
 
     replay_buffer = make_replay_buffer(device, args)

--- a/examples/ppo/ppo.py
+++ b/examples/ppo/ppo.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime
 
 from torchrl.envs import ParallelEnv
+from torchrl.envs.utils import set_exploration_mode
 
 try:
     import configargparse as argparse
@@ -98,18 +99,35 @@ def main(args):
     proof_env = transformed_env_constructor(
         args=args, use_env_creator=False, stats=stats
     )()
-    create_env_fn = parallel_env_constructor(args=args, stats=stats)
 
     model = make_ppo_model(proof_env, args=args, device=device)
     actor_model = model.get_policy_operator()
 
     loss_module = make_ppo_loss(model, args)
+    if args.gSDE:
+        with torch.no_grad(), set_exploration_mode("random"):
+            # get dimensions to build the parallel env
+            proof_td = model(proof_env.reset().to(device))
+        action_dim_gsde, state_dim_gsde = proof_td.get("_eps_gSDE").shape[-2:]
+        del proof_td
+    else:
+        action_dim_gsde, state_dim_gsde = None, None
     proof_env.close()
+    create_env_fn = parallel_env_constructor(
+        args=args,
+        stats=stats,
+        action_dim_gsde=action_dim_gsde,
+        state_dim_gsde=state_dim_gsde,
+    )
 
     collector = make_collector_onpolicy(
         make_env=create_env_fn,
         actor_model_explore=actor_model,
         args=args,
+        # make_env_kwargs=[
+        #     {"device": device} if device >= 0 else {}
+        #     for device in args.env_rendering_devices
+        # ],
     )
 
     recorder = transformed_env_constructor(

--- a/examples/redq/redq.py
+++ b/examples/redq/redq.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import datetime
 
 from torchrl.envs import ParallelEnv
+from torchrl.envs.utils import set_exploration_mode
 
 try:
     import configargparse as argparse
@@ -114,7 +115,6 @@ def main(args):
     proof_env = transformed_env_constructor(
         args=args, use_env_creator=False, stats=stats
     )()
-    create_env_fn = parallel_env_constructor(args=args, stats=stats)
     model = make_redq_model(
         proof_env,
         device=device,
@@ -131,13 +131,31 @@ def main(args):
         # mostly for debugging
         actor_model_explore.share_memory()
 
-    # make sure proof_env is closed
+    if args.gSDE:
+        with torch.no_grad(), set_exploration_mode("random"):
+            # get dimensions to build the parallel env
+            proof_td = actor_model_explore(proof_env.reset().to(device))
+        action_dim_gsde, state_dim_gsde = proof_td.get("_eps_gSDE").shape[-2:]
+        del proof_td
+    else:
+        action_dim_gsde, state_dim_gsde = None, None
+
     proof_env.close()
+    create_env_fn = parallel_env_constructor(
+        args=args,
+        stats=stats,
+        action_dim_gsde=action_dim_gsde,
+        state_dim_gsde=state_dim_gsde,
+    )
 
     collector = make_collector_offpolicy(
         make_env=create_env_fn,
         actor_model_explore=actor_model_explore,
         args=args,
+        # make_env_kwargs=[
+        #     {"device": device} if device >= 0 else {}
+        #     for device in args.env_rendering_devices
+        # ],
     )
 
     replay_buffer = make_replay_buffer(device, args)

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -54,10 +54,14 @@ class _MockEnv(_EnvClass):
     def __init__(self, seed: int = 100):
         super().__init__(
             device="cpu",
-            dtype=torch.float,
+            dtype=torch.get_default_dtype(),
         )
         self.set_seed(seed)
         self.is_closed = False
+
+        self.observation_spec = self.observation_spec.to(torch.get_default_dtype())
+        # self.action_spec = self.action_spec.to(torch.get_default_dtype())
+        self.reward_spec = self.reward_spec.to(torch.get_default_dtype())
 
     @property
     def maxstep(self):
@@ -99,13 +103,13 @@ class MockSerialEnv(_EnvClass):
 
     def _step(self, tensordict):
         self.counter += 1
-        n = torch.tensor([self.counter]).to(self.device).to(torch.float)
+        n = torch.tensor([self.counter]).to(self.device).to(torch.get_default_dtype())
         done = self.counter >= self.max_val
         done = torch.tensor([done], dtype=torch.bool, device=self.device)
         return TensorDict({"reward": n, "done": done, "next_observation": n}, [])
 
     def _reset(self, tensordict: _TensorDict, **kwargs) -> _TensorDict:
-        n = torch.tensor([self.counter]).to(self.device).to(torch.float)
+        n = torch.tensor([self.counter]).to(self.device).to(torch.get_default_dtype())
         done = self.counter >= self.max_val
         done = torch.tensor([done], dtype=torch.bool, device=self.device)
         return TensorDict({"done": done, "observation": n}, [])
@@ -158,7 +162,7 @@ class DiscreteActionVecMockEnv(_MockEnv):
         done = torch.isclose(obs, torch.ones_like(obs) * (self.counter + 1))
         reward = done.any(-1).unsqueeze(-1)
         done = done.all(-1).unsqueeze(-1)
-        tensordict.set("reward", reward.to(torch.float))
+        tensordict.set("reward", reward.to(torch.get_default_dtype()))
         tensordict.set("done", done)
         return tensordict
 
@@ -207,7 +211,7 @@ class ContinuousActionVecMockEnv(_MockEnv):
         done = torch.isclose(obs, torch.ones_like(obs) * (self.counter + 1))
         reward = done.any(-1).unsqueeze(-1)
         done = done.all(-1).unsqueeze(-1)
-        tensordict.set("reward", reward.to(torch.float))
+        tensordict.set("reward", reward.to(torch.get_default_dtype()))
         tensordict.set("done", done)
         return tensordict
 

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -57,6 +57,7 @@ class _MockEnv(_EnvClass):
             dtype=torch.float,
         )
         self.set_seed(seed)
+        self.is_closed = False
 
     @property
     def maxstep(self):
@@ -76,6 +77,10 @@ class _MockEnv(_EnvClass):
     def custom_prop(self):
         return 2
 
+    @property
+    def custom_td(self):
+        return TensorDict({"a": torch.zeros(3)}, [])
+
 
 class MockSerialEnv(_EnvClass):
     def __init__(self, device):
@@ -83,6 +88,7 @@ class MockSerialEnv(_EnvClass):
         self.action_spec = NdUnboundedContinuousTensorSpec((1,))
         self.observation_spec = NdUnboundedContinuousTensorSpec((1,))
         self.reward_spec = NdUnboundedContinuousTensorSpec((1,))
+        self.is_closed = False
 
     def set_seed(self, seed: int) -> int:
         assert seed >= 1

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -80,8 +80,8 @@ def test_concurrent_collector_consistency(num_env, env_name, seed=40):
             env = ParallelEnv(
                 num_workers=num_env,
                 create_env_fn=make_make_env(env_name),
+                create_env_kwargs=[{'seed': i} for i in range(seed, seed+num_env)],
             )
-            env.update_kwargs([{'seed': i} for i in range(seed, seed+num_env)])
             return env
 
     policy = make_policy(env_name)

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -59,9 +59,10 @@ def make_policy(env):
         raise NotImplementedError
 
 
-@pytest.mark.parametrize("num_env", [1, 3])
+@pytest.mark.parametrize("num_env", [3, 1])
 @pytest.mark.parametrize("env_name", ["conv", "vec"])
-def test_concurrent_collector_consistency(num_env, env_name, seed=100):
+def test_concurrent_collector_consistency(num_env, env_name, seed=40):
+    torch.set_default_dtype(torch.double)
     if num_env == 1:
 
         def env_fn(seed):
@@ -97,6 +98,7 @@ def test_concurrent_collector_consistency(num_env, env_name, seed=100):
             b2 = d
         else:
             break
+    print((b1["pixels"] - b2["pixels"]).norm())
     with pytest.raises(AssertionError):
         assert_allclose_td(b1, b2)
     collector.shutdown()

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -32,6 +32,7 @@ from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
 
 def make_make_env(env_name="conv"):
     def make_transformed_env():
+        torch.set_default_dtype(torch.double)
         if env_name == "conv":
             return DiscreteActionConvMockEnv()
         elif env_name == "vec":
@@ -98,7 +99,6 @@ def test_concurrent_collector_consistency(num_env, env_name, seed=40):
             b2 = d
         else:
             break
-    print((b1["pixels"] - b2["pixels"]).norm())
     with pytest.raises(AssertionError):
         assert_allclose_td(b1, b2)
     collector.shutdown()

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -61,7 +61,7 @@ def make_policy(env):
 
 
 @pytest.mark.parametrize("num_env", [3, 1])
-@pytest.mark.parametrize("env_name", ["conv", "vec"])
+@pytest.mark.parametrize("env_name", ["vec", "conv"])
 def test_concurrent_collector_consistency(num_env, env_name, seed=40):
     torch.set_default_dtype(torch.double)
     if num_env == 1:

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -457,7 +457,6 @@ def test_collector_vecnorm_envcreator():
 @pytest.mark.skipif(torch.cuda.device_count() <= 1, reason="no cuda device found")
 def test_update_weights(use_async):
     policy = torch.nn.Linear(3, 4).cuda(1)
-    policy.share_memory()
     collector_class = (
         MultiSyncDataCollector if not use_async else MultiaSyncDataCollector
     )

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -29,10 +29,11 @@ from torchrl.envs.libs.gym import _has_gym
 from torchrl.envs.transforms import TransformedEnv, VecNorm
 from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
 
+# torch.set_default_dtype(torch.double)
+
 
 def make_make_env(env_name="conv"):
-    def make_transformed_env(seed = None):
-        # torch.set_default_dtype(torch.double)
+    def make_transformed_env(seed=None):
         if env_name == "conv":
             env = DiscreteActionConvMockEnv()
         elif env_name == "vec":
@@ -66,7 +67,6 @@ def make_policy(env):
 @pytest.mark.parametrize("num_env", [3, 1])
 @pytest.mark.parametrize("env_name", ["vec", "conv"])
 def test_concurrent_collector_consistency(num_env, env_name, seed=40):
-    # torch.set_default_dtype(torch.double)
     if num_env == 1:
 
         def env_fn(seed):
@@ -80,7 +80,7 @@ def test_concurrent_collector_consistency(num_env, env_name, seed=40):
             env = ParallelEnv(
                 num_workers=num_env,
                 create_env_fn=make_make_env(env_name),
-                create_env_kwargs=[{'seed': i} for i in range(seed, seed+num_env)],
+                create_env_kwargs=[{"seed": i} for i in range(seed, seed + num_env)],
             )
             return env
 
@@ -252,7 +252,7 @@ def test_collector_consistency(num_env, env_name, seed=100):
             env = ParallelEnv(
                 num_workers=num_env,
                 create_env_fn=make_make_env(env_name),
-                create_env_kwargs=[{'seed': i} for i in range(seed, seed+num_env)],
+                create_env_kwargs=[{"seed": i} for i in range(seed, seed + num_env)],
             )
             return env
 

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -32,7 +32,7 @@ from torchrl.modules import OrnsteinUhlenbeckProcessWrapper, Actor
 
 def make_make_env(env_name="conv"):
     def make_transformed_env(seed = None):
-        torch.set_default_dtype(torch.double)
+        # torch.set_default_dtype(torch.double)
         if env_name == "conv":
             env = DiscreteActionConvMockEnv()
         elif env_name == "vec":
@@ -66,7 +66,7 @@ def make_policy(env):
 @pytest.mark.parametrize("num_env", [3, 1])
 @pytest.mark.parametrize("env_name", ["vec", "conv"])
 def test_concurrent_collector_consistency(num_env, env_name, seed=40):
-    torch.set_default_dtype(torch.double)
+    # torch.set_default_dtype(torch.double)
     if num_env == 1:
 
         def env_fn(seed):

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -810,7 +810,9 @@ def test_current_tensordict():
     tensordict = env.step(
         TensorDict(source={"action": env.action_spec.rand()}, batch_size=[])
     )
-    assert_allclose_td(step_tensordict(tensordict), env.current_tensordict)
+    assert_allclose_td(
+        step_tensordict(tensordict, exclude_done=False), env.current_tensordict
+    )
 
 
 # TODO: test for frame-skip

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -578,13 +578,18 @@ class TestParallel:
             N=N,
         )
 
-        out = env_parallel.rollout(n_steps=20)
+        assert env0.device == torch.device(device)
+        out = env0.rollout(n_steps=20)
         assert out.device == torch.device(device)
-        assert env_parallel.device == torch.device(device)
 
+        assert env_serial.device == torch.device(device)
         out = env_serial.rollout(n_steps=20)
         assert out.device == torch.device(device)
-        assert env_serial.device == torch.device(device)
+
+        assert env_parallel.device == torch.device(device)
+        out = env_parallel.rollout(n_steps=20)
+        assert out.device == torch.device(device)
+
         env_parallel.close()
         env_serial.close()
         env0.close()

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -159,7 +159,7 @@ def test_rollout(env_name, frame_skip, seed=0):
 def test_rollout_predictability(device):
     env = MockSerialEnv(device=device)
     env.set_seed(100)
-    policy = Actor(torch.nn.Linear(1, 1, bias=False))
+    policy = Actor(torch.nn.Linear(1, 1, bias=False)).to(device)
     for p in policy.parameters():
         p.data.fill_(1.0)
     td_out = env.rollout(policy=policy, n_steps=200)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -462,7 +462,7 @@ class TestParallel:
         assert all(result == 2 for result in env.custom_prop)  # to be fixed
         env.close()
 
-    @pytest.mark.skipif(not torch.has_cuda, reason="no cuda to test on")
+    @pytest.mark.skipif(not torch.cuda.device_count(), reason="no cuda to test on")
     @pytest.mark.skipif(not _has_gym, reason="no gym")
     @pytest.mark.parametrize("frame_skip", [4])
     @pytest.mark.parametrize("device", [0])
@@ -556,7 +556,7 @@ class TestParallel:
         env0.close()
 
     @pytest.mark.skipif(not _has_gym, reason="no gym")
-    @pytest.mark.skipif(not torch.has_cuda, reason="no cuda device detected")
+    @pytest.mark.skipif(not torch.cuda.device_count(), reason="no cuda device detected")
     @pytest.mark.parametrize("frame_skip", [4])
     @pytest.mark.parametrize("device", [0])
     @pytest.mark.parametrize("env_name", ["ALE/Pong-v5", "Pendulum-v1"])

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -580,11 +580,11 @@ class TestParallel:
 
         out = env_parallel.rollout(n_steps=20)
         assert out.device == torch.device(device)
-        assert env_parallel.device == device
+        assert env_parallel.device == torch.device(device)
 
         out = env_serial.rollout(n_steps=20)
         assert out.device == torch.device(device)
-        assert env_serial.device == device
+        assert env_serial.device == torch.device(device)
         env_parallel.close()
         env_serial.close()
         env0.close()

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -163,10 +163,19 @@ def test_rollout_predictability(device):
     for p in policy.parameters():
         p.data.fill_(1.0)
     td_out = env.rollout(policy=policy, n_steps=200)
-    assert (torch.arange(100, 200, device=device) == td_out.get("observation").squeeze()).all()
-    assert (torch.arange(101, 201, device=device) == td_out.get("next_observation").squeeze()).all()
-    assert (torch.arange(101, 201, device=device) == td_out.get("reward").squeeze()).all()
-    assert (torch.arange(100, 200, device=device) == td_out.get("action").squeeze()).all()
+    assert (
+        torch.arange(100, 200, device=device) == td_out.get("observation").squeeze()
+    ).all()
+    assert (
+        torch.arange(101, 201, device=device)
+        == td_out.get("next_observation").squeeze()
+    ).all()
+    assert (
+        torch.arange(101, 201, device=device) == td_out.get("reward").squeeze()
+    ).all()
+    assert (
+        torch.arange(100, 200, device=device) == td_out.get("action").squeeze()
+    ).all()
 
 
 def _make_envs(

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -163,10 +163,10 @@ def test_rollout_predictability(device):
     for p in policy.parameters():
         p.data.fill_(1.0)
     td_out = env.rollout(policy=policy, n_steps=200)
-    assert (torch.arange(100, 200) == td_out.get("observation").squeeze()).all()
-    assert (torch.arange(101, 201) == td_out.get("next_observation").squeeze()).all()
-    assert (torch.arange(101, 201) == td_out.get("reward").squeeze()).all()
-    assert (torch.arange(100, 200) == td_out.get("action").squeeze()).all()
+    assert (torch.arange(100, 200, device=device) == td_out.get("observation").squeeze()).all()
+    assert (torch.arange(101, 201, device=device) == td_out.get("next_observation").squeeze()).all()
+    assert (torch.arange(101, 201, device=device) == td_out.get("reward").squeeze()).all()
+    assert (torch.arange(100, 200, device=device) == td_out.get("action").squeeze()).all()
 
 
 def _make_envs(

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -750,6 +750,9 @@ class TestParallel:
         for c1, c2 in zip(env1.counter, env2.counter):
             assert c1 == c2
 
+        env1.close()
+        env2.close()
+
 
 class TestSpec:
     def test_discrete_action_spec_reconstruct(self):

--- a/test/test_tdmodules.py
+++ b/test/test_tdmodules.py
@@ -104,6 +104,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -115,7 +120,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=net,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -125,7 +130,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=net,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -215,6 +220,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -226,7 +236,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -236,7 +246,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -273,6 +283,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -284,7 +299,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -294,7 +309,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -384,6 +399,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 32)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(32)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -395,7 +415,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -405,7 +425,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -442,6 +462,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 32)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(32)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -453,7 +478,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -463,7 +488,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -578,6 +603,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -589,7 +619,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -599,7 +629,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -661,6 +691,11 @@ class TestTDModule:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -672,7 +707,7 @@ class TestTDModule:
             ):
                 tdmodule = ProbabilisticTensorDictModule(
                     module=tdnet,
-                    spec=CompositeSpec(out=spec, loc=None, scale=None),
+                    spec=spec,
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
@@ -682,7 +717,7 @@ class TestTDModule:
         else:
             tdmodule = ProbabilisticTensorDictModule(
                 module=tdnet,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -830,6 +865,11 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -851,7 +891,7 @@ class TestTDSequence:
                 safe=False,
             )
             tdmodule2 = ProbabilisticTensorDictModule(
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 module=net2,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
@@ -983,6 +1023,11 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -1001,7 +1046,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 fnet2,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -1151,6 +1196,11 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 7)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(7)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -1169,7 +1219,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 fnet2,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -1229,6 +1279,11 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 7)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(7)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -1240,7 +1295,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 net2,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
@@ -1385,6 +1440,11 @@ class TestTDSequence:
             spec = NdBoundedTensorSpec(-0.1, 0.1, 4)
         elif spec_type == "unbounded":
             spec = NdUnboundedContinuousTensorSpec(4)
+        else:
+            raise NotImplementedError
+        spec = (
+            CompositeSpec(out=spec, loc=None, scale=None) if spec is not None else None
+        )
 
         kwargs = {"distribution_class": TanhNormal}
 
@@ -1400,7 +1460,7 @@ class TestTDSequence:
             )
             tdmodule2 = ProbabilisticTensorDictModule(
                 fnet2,
-                spec=CompositeSpec(out=spec, loc=None, scale=None),
+                spec=spec,
                 out_key_sample=["out"],
                 dist_param_keys=["loc", "scale"],
                 safe=safe,

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1081,6 +1081,7 @@ def test_set_sub_key(index0):
     assert (td.get_sub_tensordict(idx0).get("c") == 0).all()
     assert (td0.get("c") == 0).all()
 
+
 @pytest.mark.skipif(not torch.cuda.device_count(), reason="no cuda")
 def test_create_on_device():
     device = torch.device(0)
@@ -1092,7 +1093,7 @@ def test_create_on_device():
     td.set("a", torch.randn(5, device=device))
     assert td.device == device
 
-    td = TensorDict({}, [5], device='cuda:0')
+    td = TensorDict({}, [5], device="cuda:0")
     td.set("a", torch.randn(5, 1))
     assert td.get("a").device == device
 
@@ -1104,7 +1105,7 @@ def test_create_on_device():
     subtd.set("a", torch.randn(1, device=device))
     assert subtd.device == device
 
-    td = TensorDict({}, [5], device='cuda:0')
+    td = TensorDict({}, [5], device="cuda:0")
     subtd = td[1]
     subtd.set("a", torch.randn(1))
     assert subtd.get("a").device == device
@@ -1117,7 +1118,7 @@ def test_create_on_device():
     subtd.set("a", torch.randn(2, device=device))
     assert subtd.device == device
 
-    td = TensorDict({}, [5], device='cuda:0')
+    td = TensorDict({}, [5], device="cuda:0")
     subtd = td[1:3]
     subtd.set("a", torch.randn(2))
     assert subtd.get("a").device == device
@@ -1130,7 +1131,7 @@ def test_create_on_device():
     savedtd.set("a", torch.randn(5, device=device))
     assert savedtd.device == device
 
-    td = TensorDict({}, [5], device='cuda:0')
+    td = TensorDict({}, [5], device="cuda:0")
     savedtd = td.to(SavedTensorDict)
     savedtd.set("a", torch.randn(5))
     assert savedtd.get("a").device == device
@@ -1143,12 +1144,13 @@ def test_create_on_device():
     viewedtd.set("a", torch.randn(2, 3, device=device))
     assert viewedtd.device == device
 
-    td = TensorDict({}, [6], device='cuda:0')
+    td = TensorDict({}, [6], device="cuda:0")
     viewedtd = td.view(2, 3)
     a = torch.randn(2, 3)
     viewedtd.set("a", a)
     assert viewedtd.get("a").device == device
     assert (a.unsqueeze(-1).to(device) == viewedtd.get("a")).all()
+
 
 def _remote_process(worker_id, command_pipe_child, command_pipe_parent, tensordict):
     command_pipe_parent.close()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1081,7 +1081,7 @@ def test_set_sub_key(index0):
     assert (td.get_sub_tensordict(idx0).get("c") == 0).all()
     assert (td0.get("c") == 0).all()
 
-@pytest.skip(not torch.cuda.device_count())
+@pytest.mark.skipif(not torch.cuda.device_count(), reason="no cuda")
 def test_create_on_device():
     device = torch.device(0)
 

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1097,6 +1097,25 @@ def test_create_on_device():
     td.set("a", torch.randn(5, 1))
     assert td.get("a").device == device
 
+    # stacked TensorDict
+    td1 = TensorDict({}, [5])
+    td2 = TensorDict({}, [5])
+    stackedtd = torch.stack([td1, td2], 0)
+    with pytest.raises(RuntimeError):
+        stackedtd.device
+    stackedtd.set("a", torch.randn(2, 5, device=device))
+    assert stackedtd.device == device
+    assert td1.device == device
+    assert td2.device == device
+
+    td1 = TensorDict({}, [5], device="cuda:0")
+    td2 = TensorDict({}, [5], device="cuda:0")
+    stackedtd = torch.stack([td1, td2], 0)
+    stackedtd.set("a", torch.randn(2, 5, 1))
+    assert stackedtd.get("a").device == device
+    assert td1.get("a").device == device
+    assert td2.get("a").device == device
+
     # TensorDict, indexed
     td = TensorDict({}, [5])
     subtd = td[1]

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1148,7 +1148,7 @@ def test_create_on_device():
     a = torch.randn(2, 3)
     viewedtd.set("a", a)
     assert viewedtd.get("a").device == device
-    assert (a.to(device) == viewedtd.get("a")).all()
+    assert (a.unsqueeze(-1).to(device) == viewedtd.get("a")).all()
 
 def _remote_process(worker_id, command_pipe_child, command_pipe_parent, tensordict):
     command_pipe_parent.close()

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -292,7 +292,7 @@ class SyncDataCollector(_DataCollector):
         self.return_same_td = return_same_td
 
         env.reset()
-        self._tensordict = env.current_tensordict.to(self.passing_device)
+        self._tensordict = env.current_tensordict
         self._tensordict.set(
             "step_count", torch.zeros(*self.env.batch_size, 1, dtype=torch.int)
         )

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -130,7 +130,8 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
         if policy_device != device:
             get_weights_fn = policy.state_dict
             policy = deepcopy(policy).requires_grad_(False).to(device)
-            policy.share_memory()
+            if device == torch.device("cpu"):
+                policy.share_memory()
             # if not (len(list(policy.parameters())) == 0 or next(policy.parameters()).is_shared()):
             #     raise RuntimeError("Provided policy parameters must be shared.")
         return policy, device, get_weights_fn

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -216,7 +216,7 @@ class SyncDataCollector(_DataCollector):
             at each iteration.
             default = False
         exploration_mode (str, optional): interaction mode to be used when collecting data. Must be one of "random",
-            "mode", "mean" or "param".
+            "mode" or "mean".
             default = "random"
         init_with_lag (bool, optional): if True, the first trajectory will be truncated earlier at a random step.
             This is helpful to desynchronize the environments, such that steps do no match in all collected rollouts.
@@ -271,7 +271,7 @@ class SyncDataCollector(_DataCollector):
                     )
                 env.update_kwargs(create_env_kwargs)
 
-        self.env: _EnvClass = env
+        self.env: _EnvClass = env.to(passing_device)
         self.closed = False
         self.n_env = self.env.numel()
 
@@ -387,7 +387,7 @@ class SyncDataCollector(_DataCollector):
         else:
             if td.device == torch.device("cpu") and self.pin_memory:
                 td.pin_memory()
-            self._td_policy.update(td, inplace=False)
+            self._td_policy.update(td, inplace=True)
         return self._td_policy
 
     def _cast_to_env(
@@ -398,10 +398,10 @@ class SyncDataCollector(_DataCollector):
             if self._td_env is None:
                 self._td_env = td.to(env_device)
             else:
-                self._td_env.update(td, inplace=False)
+                self._td_env.update(td, inplace=True)
             return self._td_env
         else:
-            return dest.update(td, inplace=False)
+            return dest.update(td, inplace=True)
 
     def _reset_if_necessary(self) -> None:
         done = self._tensordict.get("done")
@@ -622,7 +622,7 @@ class _MultiDataCollector(_DataCollector):
             This is helpful to desynchronize the environments, such that steps do no match in all collected rollouts.
             default = True
        exploration_mode (str, optional): interaction mode to be used when collecting data. Must be one of "random",
-            "mode", "mean" or "param".
+            "mode" or "mean".
             default = "random"
 
     """

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -110,7 +110,7 @@ class _DataCollector(IterableDataset, metaclass=abc.ABCMeta):
         #     env = None
 
         if policy is None:
-            if not hasattr(self, 'env') or self.env is None:
+            if not hasattr(self, "env") or self.env is None:
                 raise ValueError(
                     "env must be provided to _get_policy_and_device if policy is None"
                 )
@@ -466,7 +466,8 @@ class SyncDataCollector(_DataCollector):
                 self._tensordict.update(
                     step_tensordict(
                         self._tensordict.exclude("reward", "done"), keep_other=True
-                    ), inplace=True,
+                    ),
+                    inplace=True,
                 )
             if self.return_in_place and len(self._tensordict_out.keys()) > 0:
                 tensordict_out = torch.stack(tensordict_out, len(self.env.batch_size))

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -955,5 +955,6 @@ dtype=torch.float32)},
     def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> CompositeSpec:
         for value in self.values():
             value.to(dest)
-        self.device = torch.device(dest)
+        if not isinstance(dest, torch.dtype):
+            self.device = torch.device(dest)
         return self

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -903,10 +903,6 @@ dtype=torch.float32)},
                         f"Setting a new attribute ({key}) on another device ({item.device} against {self.device}). "
                         f"All devices of CompositeSpec must match."
                     )
-            # if _device is None:
-            #     raise RuntimeError(
-            #         "CompositeSpec cannot be initialized without any valid spec."
-            #     )
             self._device = _device
 
     @property
@@ -917,6 +913,12 @@ dtype=torch.float32)},
             for value in self.values():
                 if value is not None:
                     _device = value.device
+            if _device is None:
+                raise RuntimeError(
+                    "device of empty CompositeSpec is not defined. "
+                    "You can set it directly by calling"
+                    "`spec.device = device`."
+                )
             self._device = _device
         return self._device
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -903,10 +903,10 @@ dtype=torch.float32)},
                         f"Setting a new attribute ({key}) on another device ({item.device} against {self.device}). "
                         f"All devices of CompositeSpec must match."
                     )
-            if _device is None:
-                raise RuntimeError(
-                    "CompositeSpec cannot be initialized without any valid spec."
-                )
+            # if _device is None:
+            #     raise RuntimeError(
+            #         "CompositeSpec cannot be initialized without any valid spec."
+            #     )
             self._device = _device
 
     @property

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -142,6 +142,9 @@ class BoxList(Box):
     def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> BoxList:
         return BoxList([box.to(dest) for box in self.boxes])
 
+    def __iter__(self):
+        for elt in self.boxes:
+            yield elt
 
 @dataclass(repr=False)
 class BinaryBox(Box):

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -90,6 +90,9 @@ class Box:
     def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> ContinuousBox:
         raise NotImplementedError
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}()"
+
 
 @dataclass(repr=False)
 class Values:
@@ -115,6 +118,11 @@ class ContinuousBox(Box):
         self.maximum = self.maximum.to(dest)
         return self
 
+    def __repr__(self):
+        min_str = f"minimum={self.minimum}"
+        max_str = f"maximum={self.maximum}"
+        return f"{self.__class__.__name__}({min_str}, {max_str})"
+
 
 @dataclass(repr=False)
 class DiscreteBox(Box):
@@ -128,6 +136,9 @@ class DiscreteBox(Box):
 
     def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> DiscreteBox:
         return self
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(n={self.n})"
 
 
 @dataclass(repr=False)
@@ -146,6 +157,9 @@ class BoxList(Box):
         for elt in self.boxes:
             yield elt
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(boxes={self.boxes})"
+
 
 @dataclass(repr=False)
 class BinaryBox(Box):
@@ -158,6 +172,9 @@ class BinaryBox(Box):
 
     def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> ContinuousBox:
         return self
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(n={self.n})"
 
 
 @dataclass(repr=False)
@@ -316,7 +333,9 @@ class TensorSpec:
         device_str = "device=" + str(self.device)
         dtype_str = "dtype=" + str(self.dtype)
         domain_str = "domain=" + str(self.domain)
-        sub_string = ",".join([shape_str, space_str, device_str, dtype_str, domain_str])
+        sub_string = ", ".join(
+            [shape_str, space_str, device_str, dtype_str, domain_str]
+        )
         string = f"{self.__class__.__name__}(\n     {sub_string})"
         return string
 

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -907,7 +907,22 @@ dtype=torch.float32)},
                 raise RuntimeError(
                     "CompositeSpec cannot be initialized without any valid spec."
                 )
-            self.device = _device
+            self._device = _device
+
+    @property
+    def device(self) -> DEVICE_TYPING:
+        if self._device is None:
+            # try to replace device by the true device
+            _device = None
+            for value in self.values():
+                if value is not None:
+                    _device = value.device
+            self._device = _device
+        return self._device
+
+    @device.setter
+    def device(self, value: DEVICE_TYPING):
+        self._device = value
 
     def __getitem__(self, item):
         if item in {"shape", "device", "dtype", "space"}:

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -146,6 +146,7 @@ class BoxList(Box):
         for elt in self.boxes:
             yield elt
 
+
 @dataclass(repr=False)
 class BinaryBox(Box):
     """

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1477,8 +1477,6 @@ class TensorDict(_TensorDict):
             )
 
         map_item_to_device = device is not None
-        if map_item_to_device:
-            device = self.device
         self._device = device
 
         if source is not None:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2519,7 +2519,7 @@ class LazyStackedTensorDict(_TensorDict):
                 "StackedTensorDict to be instantiated"
             )
         _batch_size = tensordicts[0].batch_size
-        device = tensordicts[0].device
+        device = tensordicts[0]._device_safe()
 
         for i, td in enumerate(tensordicts[1:]):
             if not isinstance(td, _TensorDict):
@@ -2528,7 +2528,7 @@ class LazyStackedTensorDict(_TensorDict):
                     f" but got {type(tensordicts[0])} instead."
                 )
             _bs = td.batch_size
-            _device = td.device
+            _device = td._device_safe()
             if device != _device:
                 raise RuntimeError(f"devices differ, got {device} and {_device}")
             if _bs != _batch_size:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1827,7 +1827,7 @@ class TensorDict(_TensorDict):
             try:
                 if dest == self.device:
                     return self
-            except:
+            except RuntimeError:
                 pass
 
             self_copy = TensorDict(

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2941,7 +2941,7 @@ class SavedTensorDict(_TensorDict):
             if (hasattr(source, "_device_safe") and source._device_safe() is not None)
             else source[list(source.keys())[0]].device
             if len(source)
-            else torch.device("cpu")
+            else None
         )
         td = source
         self._save(td)

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1478,7 +1478,7 @@ class TensorDict(_TensorDict):
 
         map_item_to_device = device is not None
         if map_item_to_device:
-            device = torch.device
+            device = self.device
         self._device = device
 
         if source is not None:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2939,6 +2939,8 @@ class SavedTensorDict(_TensorDict):
             if device is not None
             else source._device_safe()
             if (hasattr(source, "_device_safe") and source._device_safe() is not None)
+            else source[list(source.keys())[0]].device
+            if len(source)
             else torch.device("cpu")
         )
         td = source

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -295,7 +295,7 @@ class _TensorDict(Mapping, metaclass=abc.ABCMeta):
                 the transformation.
 
         Returns:
-            a new tensordict with transformed tensors.
+            a new tensordict with transformed_in tensors.
 
         """
         if batch_size is None:
@@ -2730,11 +2730,11 @@ class LazyStackedTensorDict(_TensorDict):
         self._valid_keys = sorted(list(valid_keys))
 
     def select(self, *keys: str, inplace: bool = False) -> _TensorDict:
-        if len(set(self.valid_keys).intersection(keys)) != len(keys):
-            raise KeyError(
-                f"Selected and existing keys mismatch, got self.valid_keys"
-                f"={self.valid_keys} and keys={keys}"
-            )
+        # if len(set(self.valid_keys).intersection(keys)) != len(keys):
+        #     raise KeyError(
+        #         f"Selected and existing keys mismatch, got self.valid_keys"
+        #         f"={self.valid_keys} and keys={keys}"
+        #     )
         tensordicts = [td.select(*keys, inplace=inplace) for td in self.tensordicts]
         if inplace:
             return self
@@ -3327,7 +3327,7 @@ class _CustomOpTensorDict(_TensorDict):
         )
         if transformed_tensor.data_ptr() != original_tensor.data_ptr():
             raise RuntimeError(
-                f"{self} original tensor and transformed do not point to the "
+                f"{self} original tensor and transformed_in do not point to the "
                 f"same storage. Setting values in place is not currently "
                 f"supported in this setting, consider calling "
                 f"`td.clone()` before `td.set_at_(...)`"

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1824,8 +1824,11 @@ class TensorDict(_TensorDict):
         elif isinstance(dest, (torch.device, str, int)):
             # must be device
             dest = torch.device(dest)
-            if dest == self._device:
-                return self
+            try:
+                if dest == self.device:
+                    return self
+            except:
+                pass
 
             self_copy = TensorDict(
                 source={key: value.to(dest) for key, value in self.items()},

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2937,10 +2937,8 @@ class SavedTensorDict(_TensorDict):
         self._device = (
             torch.device(device)
             if device is not None
-            else source.device
-            if hasattr(source, "device")
-            else source[list(source.keys())[0]].device
-            if len(source)
+            else source._device_safe()
+            if (hasattr(source, "_device_safe") and source._device_safe() is not None)
             else torch.device("cpu")
         )
         td = source

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2972,7 +2972,17 @@ class SavedTensorDict(_TensorDict):
 
     @property
     def device(self) -> torch.device:
-        return self._device
+        device = self._device
+        if device is None and not self.is_empty():
+            for _, item in self.items_meta():
+                device = item.device
+                break
+        elif device is None:
+            raise RuntimeError(
+                "querying device from an empty tensordict is not permitted, "
+                "unless this device has been specified upon creation."
+            )
+        return device
 
     @device.setter
     def device(self, value: DEVICE_TYPING) -> None:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -307,7 +307,9 @@ class _TensorDict(Mapping, metaclass=abc.ABCMeta):
         if batch_size is None:
             td = TensorDict({}, batch_size=self.batch_size, device=self._device_safe())
         else:
-            td = TensorDict({}, batch_size=torch.Size(batch_size), device=self._device_safe())
+            td = TensorDict(
+                {}, batch_size=torch.Size(batch_size), device=self._device_safe()
+            )
         for key, item in self.items():
             item_trsf = fn(item)
             td.set(key, item_trsf)
@@ -591,7 +593,9 @@ dtype=torch.float32)},
         d = dict()
         for (key, item1) in self.items():
             d[key] = item1 != other.get(key)
-        return TensorDict(batch_size=self.batch_size, source=d, device=self._device_safe())
+        return TensorDict(
+            batch_size=self.batch_size, source=d, device=self._device_safe()
+        )
 
     def __eq__(self, other: object) -> _TensorDict:
         """Compares two tensordicts against each other, for evey key. The two
@@ -616,7 +620,9 @@ dtype=torch.float32)},
         d = dict()
         for (key, item1) in self.items():
             d[key] = item1 == other.get(key)
-        return TensorDict(batch_size=self.batch_size, source=d, device=self._device_safe())
+        return TensorDict(
+            batch_size=self.batch_size, source=d, device=self._device_safe()
+        )
 
     @abc.abstractmethod
     def del_(self, key: str) -> _TensorDict:
@@ -954,7 +960,9 @@ dtype=torch.float32)},
             value_select = value[mask_expand]
             d[key] = value_select
         dim = int(mask.sum().item())
-        return TensorDict(device=self._device_safe(), source=d, batch_size=torch.Size([dim]))
+        return TensorDict(
+            device=self._device_safe(), source=d, batch_size=torch.Size([dim])
+        )
 
     @abc.abstractmethod
     def is_contiguous(self) -> bool:
@@ -2260,7 +2268,6 @@ torch.Size([3, 2])
         elif isinstance(dest, (torch.device, str, int)):
             dest = torch.device(dest)
             try:
-                self_device = self.device
                 if dest == self.device:
                     return self
             except RuntimeError:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2957,7 +2957,7 @@ class SavedTensorDict(_TensorDict):
         torch.save(tensordict, self.filename)
 
     def _load(self) -> _TensorDict:
-        return torch.load(self.filename, self.device)
+        return torch.load(self.filename, map_location=self._device_safe())
 
     def _get_meta(self, key: str) -> MetaTensor:
         return self._tensordict_meta.get(key)

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -204,7 +204,7 @@ class _EnvClass:
                 "tensordict.select()) inside _step before writing new tensors onto this new instance."
             )
         self.is_done = tensordict_out.get("done")
-        self.current_tensordict = step_tensordict(tensordict_out)
+        self.current_tensordict = step_tensordict(tensordict_out, exclude_done=False)
 
         for key in self._select_observation_keys(tensordict_out):
             obs = tensordict_out.get(key)

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -134,7 +134,8 @@ class _EnvClass:
         device: DEVICE_TYPING = "cpu",
         dtype: Optional[Union[torch.dtype, np.dtype]] = None,
     ):
-        self.device = torch.device(device)
+        if device is not None:
+            self.device = torch.device(device)
         self._is_done = None
         self.dtype = dtype_map.get(dtype, dtype)
         self.is_closed = True

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -319,7 +319,7 @@ class _EnvClass:
     @current_tensordict.setter
     def current_tensordict(self, value: Union[_TensorDict, dict]):
         if isinstance(self._current_tensordict, _TensorDict):
-            self._current_tensordict.update(value, inplace=True)
+            self._current_tensordict.update_(value)
             return
         if isinstance(value, dict):
             value = TensorDict(value, self.batch_size)
@@ -437,6 +437,7 @@ class _EnvClass:
         tensordict = self.current_tensordict
 
         if policy is None:
+
             def policy(td):
                 return td.set("action", self.action_spec.rand(self.batch_size))
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -709,7 +709,7 @@ class GymLikeEnv(_EnvWrapper):
     def _reset(self, tensordict: Optional[_TensorDict] = None, **kwargs) -> _TensorDict:
         obs, *_ = self._output_transform((self._env.reset(**kwargs),))
         tensordict_out = TensorDict(
-            source=self._read_obs(obs), batch_size=self.batch_size
+            source=self._read_obs(obs), batch_size=self.batch_size, device=self.device,
         )
         self._is_done = torch.zeros(1, dtype=torch.bool)
         tensordict_out.set("done", self._is_done)

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -709,7 +709,9 @@ class GymLikeEnv(_EnvWrapper):
     def _reset(self, tensordict: Optional[_TensorDict] = None, **kwargs) -> _TensorDict:
         obs, *_ = self._output_transform((self._env.reset(**kwargs),))
         tensordict_out = TensorDict(
-            source=self._read_obs(obs), batch_size=self.batch_size, device=self.device,
+            source=self._read_obs(obs),
+            batch_size=self.batch_size,
+            device=self.device,
         )
         self._is_done = torch.zeros(1, dtype=torch.bool)
         tensordict_out.set("done", self._is_done)

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+import os
 from typing import Optional, Tuple, Union
 
 import numpy as np
@@ -14,7 +14,7 @@ from torchrl.data import (
     NdUnboundedContinuousTensorSpec,
     TensorSpec,
 )
-from ...data.utils import numpy_to_torch_dtype_dict
+from ...data.utils import numpy_to_torch_dtype_dict, DEVICE_TYPING
 from ..common import GymLikeEnv
 
 __all__ = ["DMControlEnv"]
@@ -129,6 +129,7 @@ class DMControlEnv(GymLikeEnv):
             kwargs = {"random": random_state}
         env = suite.load(envname, taskname, task_kwargs=kwargs)
         if from_pixels:
+            self._set_egl_device(self.device)
             self.render_kwargs = {"camera_id": 0}
             if render_kwargs is not None:
                 self.render_kwargs.update(render_kwargs)
@@ -139,6 +140,24 @@ class DMControlEnv(GymLikeEnv):
             )
         self._env = env
         return env
+
+    def _set_egl_device(self, device: DEVICE_TYPING):
+        if device != torch.device("cpu"):
+            device_id = str(device).split(":")[-1]
+            if (
+                "EGL_DEVICE_ID" in os.environ
+                and os.environ["EGL_DEVICE_ID"] != device_id
+            ):
+                raise RuntimeError(
+                    f"Conflicting devices for DMControl env pixel rendering: "
+                    f"got {device_id} but device already set to {os.environ['EGL_DEVICE_ID']}"
+                )
+            print(f"rendering on device {device_id}")
+            os.environ["EGL_DEVICE_ID"] = device_id
+
+    def to(self, device: DEVICE_TYPING):
+        super().to(device)
+        self._set_egl_device(self.device)
 
     def _init_env(self, seed: Optional[int] = None) -> Optional[int]:
         seed = self.set_seed(seed)

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -2,6 +2,8 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import annotations
+
 import os
 from typing import Optional, Tuple, Union
 
@@ -155,9 +157,10 @@ class DMControlEnv(GymLikeEnv):
             print(f"rendering on device {device_id}")
             os.environ["EGL_DEVICE_ID"] = device_id
 
-    def to(self, device: DEVICE_TYPING):
+    def to(self, device: DEVICE_TYPING) -> DMControlEnv:
         super().to(device)
         self._set_egl_device(self.device)
+        return self
 
     def _init_env(self, seed: Optional[int] = None) -> Optional[int]:
         seed = self.set_seed(seed)

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -58,11 +58,11 @@ def _gym_to_torchrl_spec_transform(spec, dtype=None, device="cpu") -> TensorSpec
     if isinstance(spec, gym.spaces.tuple.Tuple):
         raise NotImplementedError("gym.spaces.tuple.Tuple mapping not yet implemented")
     if isinstance(spec, gym.spaces.discrete.Discrete):
-        return OneHotDiscreteTensorSpec(spec.n)
+        return OneHotDiscreteTensorSpec(spec.n, device=device)
     elif isinstance(spec, gym.spaces.multi_binary.MultiBinary):
-        return BinaryDiscreteTensorSpec(spec.n)
+        return BinaryDiscreteTensorSpec(spec.n, device=device)
     elif isinstance(spec, gym.spaces.multi_discrete.MultiDiscrete):
-        return MultOneHotDiscreteTensorSpec(spec.nvec)
+        return MultOneHotDiscreteTensorSpec(spec.nvec, device=device)
     elif isinstance(spec, gym.spaces.Box):
         if dtype is None:
             dtype = numpy_to_torch_dtype_dict[spec.dtype]
@@ -71,9 +71,13 @@ def _gym_to_torchrl_spec_transform(spec, dtype=None, device="cpu") -> TensorSpec
             torch.tensor(spec.high, device=device, dtype=dtype),
             torch.Size(spec.shape),
             dtype=dtype,
+            device=device,
         )
     elif isinstance(spec, (dict, gym.spaces.dict.Dict)):
-        spec = {"next_" + k: _gym_to_torchrl_spec_transform(spec[k]) for k in spec}
+        spec = {
+            "next_" + k: _gym_to_torchrl_spec_transform(spec[k], device=device)
+            for k in spec
+        }
         return CompositeSpec(**spec)
     else:
         raise NotImplementedError(
@@ -169,17 +173,19 @@ class GymEnv(GymLikeEnv):
             self._env.reset()
             self._env = PixelObservationWrapper(self._env, pixels_only)
 
-        self.action_spec = _gym_to_torchrl_spec_transform(self._env.action_space).to(self.device)
+        self.action_spec = _gym_to_torchrl_spec_transform(
+            self._env.action_space, device=self.device
+        )
         self.observation_spec = _gym_to_torchrl_spec_transform(
-            self._env.observation_space
-        ).to(self.device)
+            self._env.observation_space, device=self.device
+        )
         if not isinstance(self.observation_spec, CompositeSpec):
             self.observation_spec = CompositeSpec(
                 next_observation=self.observation_spec
             )
         self.reward_spec = UnboundedContinuousTensorSpec(
             device=self.device,
-        ).to(self.device)  # default
+        )
 
     def _init_env(self):
         self.reset()  # make sure that _current_observation and

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -169,17 +169,17 @@ class GymEnv(GymLikeEnv):
             self._env.reset()
             self._env = PixelObservationWrapper(self._env, pixels_only)
 
-        self.action_spec = _gym_to_torchrl_spec_transform(self._env.action_space)
+        self.action_spec = _gym_to_torchrl_spec_transform(self._env.action_space).to(self.device)
         self.observation_spec = _gym_to_torchrl_spec_transform(
             self._env.observation_space
-        )
+        ).to(self.device)
         if not isinstance(self.observation_spec, CompositeSpec):
             self.observation_spec = CompositeSpec(
                 next_observation=self.observation_spec
             )
         self.reward_spec = UnboundedContinuousTensorSpec(
             device=self.device,
-        )  # default
+        ).to(self.device)  # default
 
     def _init_env(self):
         self.reset()  # make sure that _current_observation and

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -10,7 +10,7 @@ from typing import Any, List, Optional, OrderedDict, Sequence, Union
 from warnings import warn
 
 import torch
-from torch import nn
+from torch import nn, Tensor
 
 try:
     _has_tv = True
@@ -28,6 +28,7 @@ from torchrl.data.tensor_specs import (
     TensorSpec,
     UnboundedContinuousTensorSpec,
     BinaryDiscreteTensorSpec,
+    DEVICE_TYPING,
 )
 from torchrl.data.tensordict.tensordict import _TensorDict, TensorDict
 from torchrl.envs.common import _EnvClass, make_tensordict
@@ -82,7 +83,7 @@ class Transform(nn.Module):
     Notably, `Transform` subclasses take care of transforming the affected
     specs from an environment: when querying
     `transformed_env.observation_spec`, the resulting objects will describe
-    the specs of the transformed tensors.
+    the specs of the transformed_in tensors.
 
     """
 
@@ -106,7 +107,7 @@ class Transform(nn.Module):
     def init(self, tensordict) -> None:
         pass
 
-    def _apply(self, obs: torch.Tensor) -> None:
+    def _apply_transform(self, obs: torch.Tensor) -> None:
         """Applies the transform to a tensor.
         This operation can be called multiple times (if multiples keys of the
         tensordict match the keys of the transform).
@@ -122,7 +123,7 @@ class Transform(nn.Module):
         self._check_inplace()
         for _obs_key in tensordict.keys():
             if _obs_key in self.keys:
-                observation = self._apply(tensordict.get(_obs_key))
+                observation = self._apply_transform(tensordict.get(_obs_key))
                 tensordict.set(_obs_key, observation, inplace=self.inplace)
         return tensordict
 
@@ -130,7 +131,7 @@ class Transform(nn.Module):
         self._call(tensordict)
         return tensordict
 
-    def _inv_apply(self, obs: torch.Tensor) -> torch.Tensor:
+    def _inv_apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         if self.invertible:
             raise NotImplementedError
         else:
@@ -140,7 +141,7 @@ class Transform(nn.Module):
         self._check_inplace()
         for _obs_key in tensordict.keys():
             if _obs_key in self.keys:
-                observation = self._inv_apply(tensordict.get(_obs_key))
+                observation = self._inv_apply_transform(tensordict.get(_obs_key))
                 tensordict.set(_obs_key, observation, inplace=self.inplace)
         return tensordict
 
@@ -217,16 +218,16 @@ class Transform(nn.Module):
 
 class TransformedEnv(_EnvClass):
     """
-    A transformed environment.
+    A transformed_in environment.
 
     Args:
-        env (_EnvClass): original environment to be transformed.
+        env (_EnvClass): original environment to be transformed_in.
         transform (Transform, optional): transform to apply to the tensordict resulting
             from `env.step(td)`. If none is provided, an empty Compose placeholder is
             used.
         cache_specs (bool, optional): if True, the specs will be cached once
             and for all after the first call (i.e. the specs will be
-            transformed only once). If the transform changes during
+            transformed_in only once). If the transform changes during
             training, the original spec transform may not be valid anymore,
             in which case this value should be set  to `False`. Default is
             `True`.
@@ -258,13 +259,14 @@ class TransformedEnv(_EnvClass):
         self._reward_spec = None
         self._observation_spec = None
         self.batch_size = self.env.batch_size
-        self.is_closed = False
 
+        kwargs.setdefault("device", env.device)
+        self.transform.to(kwargs["device"])
         super().__init__(**kwargs)
 
     @property
     def observation_spec(self) -> TensorSpec:
-        """Observation spec of the transformed environment"""
+        """Observation spec of the transformed_in environment"""
         if self._observation_spec is None or not self.cache_specs:
             observation_spec = self.transform.transform_observation_spec(
                 deepcopy(self.env.observation_spec)
@@ -277,7 +279,7 @@ class TransformedEnv(_EnvClass):
 
     @property
     def action_spec(self) -> TensorSpec:
-        """Action spec of the transformed environment"""
+        """Action spec of the transformed_in environment"""
 
         if self._action_spec is None or not self.cache_specs:
             action_spec = self.transform.transform_action_spec(
@@ -291,7 +293,7 @@ class TransformedEnv(_EnvClass):
 
     @property
     def reward_spec(self) -> TensorSpec:
-        """Reward spec of the transformed environment"""
+        """Reward spec of the transformed_in environment"""
 
         if self._reward_spec is None or not self.cache_specs:
             reward_spec = self.transform.transform_reward_spec(
@@ -307,7 +309,7 @@ class TransformedEnv(_EnvClass):
         selected_keys = [key for key in tensordict.keys() if "action" in key]
         tensordict_in = tensordict.select(*selected_keys).clone()
         tensordict_in = self.transform.inv(tensordict_in)
-        tensordict_out = self.env._step(tensordict_in).to(self.device)
+        tensordict_out = self.env._step(tensordict_in)
         # tensordict should already have been processed by the transforms
         # for logging purposes
         tensordict_out = self.transform(tensordict_out)
@@ -338,9 +340,17 @@ class TransformedEnv(_EnvClass):
         self.transform.train(mode)
         return self
 
+    @property
+    def is_closed(self) -> bool:
+        return self.env.is_closed
+
+    @is_closed.setter
+    def is_closed(self, value: bool):
+        self.env.is_closed = value
+
     def close(self):
-        self.is_closed = True
         self.env.close()
+        self.is_closed = True
 
     def empty_cache(self):
         self._observation_spec = None
@@ -379,6 +389,23 @@ class TransformedEnv(_EnvClass):
 
     def __repr__(self) -> str:
         return f"TransformedEnv(env={self.env}, transform={self.transform})"
+
+    def to(self, device: DEVICE_TYPING) -> TransformedEnv:
+        self.env.to(device)
+        self.device = torch.device(device)
+        self.transform.to(device)
+
+        if self._current_tensordict is not None:
+            current_tensordict = self.current_tensordict.to(device)
+            self._current_tensordict = None
+            self.current_tensordict = current_tensordict
+        self.is_done = self.is_done.to(device)
+
+        if self.cache_specs:
+            self._action_spec = None
+            self._observation_spec = None
+            self._reward_spec = None
+        return self
 
 
 class ObservationTransform(Transform):
@@ -469,6 +496,11 @@ class Compose(Transform):
         self.transforms.append(transform)
         transform.set_parent(self)
 
+    def to(self, dest: Union[torch.dtype, DEVICE_TYPING]) -> Compose:
+        for t in self.transforms:
+            t.to(dest)
+        return super().to(dest)
+
     def __len__(self):
         return len(self.transforms)
 
@@ -517,7 +549,7 @@ class ToTensorImage(ObservationTransform):
         self.unsqueeze = unsqueeze
         self.dtype = dtype if dtype is not None else torch.get_default_dtype()
 
-    def _apply(self, observation: torch.FloatTensor) -> torch.Tensor:
+    def _apply_transform(self, observation: torch.FloatTensor) -> torch.Tensor:
         observation = observation.div(255).to(self.dtype)
         observation = observation.permute(
             *list(range(observation.ndimension() - 3)), -1, -3, -2
@@ -553,8 +585,8 @@ class ToTensorImage(ObservationTransform):
 
     def _pixel_observation(self, spec: TensorSpec) -> None:
         if isinstance(spec, BoundedTensorSpec):
-            spec.space.maximum = self._apply(spec.space.maximum)
-            spec.space.minimum = self._apply(spec.space.minimum)
+            spec.space.maximum = self._apply_transform(spec.space.maximum)
+            spec.space.minimum = self._apply_transform(spec.space.minimum)
 
 
 class RewardClipping(Transform):
@@ -578,10 +610,16 @@ class RewardClipping(Transform):
         if keys is None:
             keys = ["reward"]
         super().__init__(keys=keys)
-        self.clamp_min = clamp_min
-        self.clamp_max = clamp_max
+        clamp_min_tensor = (
+            clamp_min if isinstance(clamp_min, Tensor) else torch.tensor(clamp_min)
+        )
+        clamp_max_tensor = (
+            clamp_max if isinstance(clamp_max, Tensor) else torch.tensor(clamp_max)
+        )
+        self.register_buffer("clamp_min", clamp_min_tensor)
+        self.register_buffer("clamp_max", clamp_max_tensor)
 
-    def _apply(self, reward: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, reward: torch.Tensor) -> torch.Tensor:
         if self.clamp_max is not None and self.clamp_min is not None:
             reward = reward.clamp_(self.clamp_min, self.clamp_max)
         elif self.clamp_min is not None:
@@ -627,7 +665,7 @@ class BinarizeReward(Transform):
             keys = ["reward"]
         super().__init__(keys=keys)
 
-    def _apply(self, reward: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, reward: torch.Tensor) -> torch.Tensor:
         if not reward.shape or reward.shape[-1] != 1:
             raise RuntimeError(
                 f"Reward shape last dimension must be singleton, got reward of shape {reward.shape}"
@@ -670,7 +708,7 @@ class Resize(ObservationTransform):
         self.h = h
         self.interpolation = interpolation
 
-    def _apply(self, observation: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, observation: torch.Tensor) -> torch.Tensor:
         observation = resize(
             observation, [self.w, self.h], interpolation=self.interpolation
         )
@@ -691,11 +729,11 @@ class Resize(ObservationTransform):
             _observation_spec = observation_spec
         space = _observation_spec.space
         if isinstance(space, ContinuousBox):
-            space.minimum = self._apply(space.minimum)
-            space.maximum = self._apply(space.maximum)
+            space.minimum = self._apply_transform(space.minimum)
+            space.maximum = self._apply_transform(space.maximum)
             _observation_spec.shape = space.minimum.shape
         else:
-            _observation_spec.shape = self._apply(
+            _observation_spec.shape = self._apply_transform(
                 torch.zeros(_observation_spec.shape)
             ).shape
 
@@ -723,7 +761,7 @@ class GrayScale(ObservationTransform):
             keys = IMAGE_KEYS
         super(GrayScale, self).__init__(keys=keys)
 
-    def _apply(self, observation: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, observation: torch.Tensor) -> torch.Tensor:
         observation = F.rgb_to_grayscale(observation)
         return observation
 
@@ -741,11 +779,11 @@ class GrayScale(ObservationTransform):
             _observation_spec = observation_spec
         space = _observation_spec.space
         if isinstance(space, ContinuousBox):
-            space.minimum = self._apply(space.minimum)
-            space.maximum = self._apply(space.maximum)
+            space.minimum = self._apply_transform(space.minimum)
+            space.maximum = self._apply_transform(space.maximum)
             _observation_spec.shape = space.minimum.shape
         else:
-            _observation_spec.shape = self._apply(
+            _observation_spec.shape = self._apply_transform(
                 torch.zeros(_observation_spec.shape)
             ).shape
         observation_spec = _observation_spec
@@ -816,7 +854,7 @@ class ObservationNorm(ObservationTransform):
         eps = 1e-6
         self.register_buffer("scale", scale.clamp_min(eps))
 
-    def _apply(self, obs: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         if self.standard_normal:
             loc = self.loc
             scale = self.scale
@@ -836,8 +874,8 @@ class ObservationNorm(ObservationTransform):
             return observation_spec
         space = observation_spec.space
         if isinstance(space, ContinuousBox):
-            space.minimum = self._apply(space.minimum)
-            space.maximum = self._apply(space.maximum)
+            space.minimum = self._apply_transform(space.minimum)
+            space.maximum = self._apply_transform(space.maximum)
         return observation_spec
 
     def __repr__(self) -> str:
@@ -912,7 +950,7 @@ class CatFrames(ObservationTransform):
         observation_spec = _observation_spec
         return observation_spec
 
-    def _apply(self, obs: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         self.buffer.append(obs)
         self.buffer = self.buffer[-self.N :]
         buffer = list(reversed(self.buffer))
@@ -961,7 +999,7 @@ class RewardScaling(Transform):
         self.register_buffer("loc", loc)
         self.register_buffer("scale", scale.clamp_min(1e-6))
 
-    def _apply(self, reward: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, reward: torch.Tensor) -> torch.Tensor:
         reward.mul_(self.scale).add_(self.loc)
         return reward
 
@@ -1032,10 +1070,10 @@ class DoubleToFloat(Transform):
             keys = ["action"]
         super().__init__(keys=keys)
 
-    def _apply(self, obs: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         return obs.to(torch.float)
 
-    def _inv_apply(self, obs: torch.Tensor) -> torch.Tensor:
+    def _inv_apply_transform(self, obs: torch.Tensor) -> torch.Tensor:
         return obs.to(torch.double)
 
     def _transform_spec(self, spec: TensorSpec) -> None:
@@ -1224,7 +1262,7 @@ class DiscreteActionProjection(Transform):
         self.max_N = max_N
         self.M = M
 
-    def _inv_apply(self, action: torch.Tensor) -> torch.Tensor:
+    def _inv_apply_transform(self, action: torch.Tensor) -> torch.Tensor:
         if action.shape[-1] < self.M:
             raise RuntimeError(
                 f"action.shape[-1]={action.shape[-1]} is smaller than "
@@ -1337,19 +1375,35 @@ class gSDENoise(Transform):
 
     def __init__(
         self,
+        state_dim=None,
+        action_dim=None,
     ) -> None:
         super().__init__(keys=[])
+        self.state_dim = state_dim
+        self.action_dim = action_dim
 
     def reset(self, tensordict: _TensorDict) -> _TensorDict:
         tensordict = super().reset(tensordict=tensordict)
-        tensordict.set(
-            "_eps_gSDE",
-            torch.zeros(
-                *tensordict.batch_size,
-                1,
-                device=tensordict.device,
-            ),
-        )
+        if self.state_dim is None or self.action_dim is None:
+            tensordict.set(
+                "_eps_gSDE",
+                torch.zeros(
+                    *tensordict.batch_size,
+                    1,
+                    device=tensordict.device,
+                ),
+            )
+        else:
+            tensordict.set(
+                "_eps_gSDE",
+                torch.randn(
+                    *tensordict.batch_size,
+                    self.action_dim,
+                    self.state_dim,
+                    device=tensordict.device,
+                ),
+            )
+
         return tensordict
 
 

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -246,9 +246,13 @@ class TransformedEnv(_EnvClass):
         cache_specs: bool = True,
         **kwargs,
     ):
+        kwargs.setdefault("device", env.device)
+        device = kwargs["device"]
         self.env = env
         if transform is None:
             transform = Compose()
+        else:
+            transform = transform.to(device)
         self.transform = transform
         transform.set_parent(self)  # allows to find env specs from the transform
 
@@ -260,8 +264,6 @@ class TransformedEnv(_EnvClass):
         self._observation_spec = None
         self.batch_size = self.env.batch_size
 
-        kwargs.setdefault("device", env.device)
-        self.transform.to(kwargs["device"])
         super().__init__(**kwargs)
 
     @property
@@ -364,6 +366,7 @@ class TransformedEnv(_EnvClass):
                 "TransformedEnv.append_transform expected a transform but received an object of "
                 f"type {type(transform)} instead."
             )
+        transform = transform.to(self.device)
         if not isinstance(self.transform, Compose):
             self.transform = Compose(self.transform)
             self.transform.set_parent(self)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -358,6 +358,7 @@ class TransformedEnv(_EnvClass):
         self._reward_spec = None
 
     def append_transform(self, transform: Transform) -> None:
+        self._erase_metadata()
         if not isinstance(transform, Transform):
             raise ValueError(
                 "TransformedEnv.append_transform expected a transform but received an object of "
@@ -389,6 +390,13 @@ class TransformedEnv(_EnvClass):
 
     def __repr__(self) -> str:
         return f"TransformedEnv(env={self.env}, transform={self.transform})"
+
+    def _erase_metadata(self):
+        self._current_tensordict = None
+        if self.cache_specs:
+            self._action_spec = None
+            self._observation_spec = None
+            self._reward_spec = None
 
     def to(self, device: DEVICE_TYPING) -> TransformedEnv:
         self.env.to(device)

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -248,7 +248,7 @@ class TransformedEnv(_EnvClass):
     ):
         kwargs.setdefault("device", env.device)
         device = kwargs["device"]
-        self.env = env
+        self.env = env.to(device)
         if transform is None:
             transform = Compose()
         else:

--- a/torchrl/envs/utils.py
+++ b/torchrl/envs/utils.py
@@ -22,7 +22,9 @@ def step_tensordict(
     tensordict: _TensorDict,
     next_tensordict: _TensorDict = None,
     keep_other: bool = True,
-    exclude_reward_done_action: bool = True,
+    exclude_reward: bool = True,
+    exclude_done: bool = True,
+    exclude_action: bool = True,
 ) -> _TensorDict:
     """
     Given a tensordict retrieved after a step, returns another tensordict with all the 'next_' prefixes are removed,
@@ -34,8 +36,14 @@ def step_tensordict(
         next_tensordict (_TensorDict, optional): destination tensordict
         keep_other (bool, optional): if True, all keys that do not start with `'next_'` will be kept.
             Default is True.
-        exclude_reward_done_action (bool, optional): if True, `"reward"` and `"done"` keys will be discarded
-            from the resulting tensordict ast they are considered to be time-sensitive.
+        exclude_reward (bool, optional): if True, the `"reward"` key will be discarded
+            from the resulting tensordict.
+            Default is True.
+        exclude_done (bool, optional): if True, the `"done"` key will be discarded
+            from the resulting tensordict.
+            Default is True.
+        exclude_action (bool, optional): if True, the `"action"` key will be discarded
+            from the resulting tensordict.
             Default is True.
 
     Returns:
@@ -58,9 +66,16 @@ def step_tensordict(
 
     """
     other_keys = []
-    if exclude_reward_done_action:
+    to_exclude = []
+    if exclude_done:
+        to_exclude.append("done")
+    if exclude_reward:
+        to_exclude.append("reward")
+    if exclude_action:
+        to_exclude.append("action")
+    if to_exclude:
         # we exclude those keys to make sure we aren't reporting time-specific values at the next step.
-        tensordict = tensordict.exclude("reward", "done", "action")
+        tensordict = tensordict.exclude(*to_exclude)
     keys = [key for key in tensordict.keys() if key.startswith("next_")]
     new_keys = [key[5:] for key in keys]
     if keep_other:

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -418,7 +418,7 @@ class _BatchedEnv(_EnvClass):
         device = torch.device(device)
         if device == self.device:
             return self
-        self.device = device
+        self._device = device
         if not self.is_closed:
             warn(
                 "Casting an open environment to another device requires closing and re-opening it. "

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -374,7 +374,13 @@ class _BatchedEnv(_EnvClass):
             raise RuntimeError("trying to close a closed environment")
         if self._verbose:
             print(f"closing {self.__class__.__name__}")
+
         self._current_tensordict = None
+
+        self.action_spec = None
+        self.observation_spec = None
+        self.reward_spec = None
+
         self._shutdown_workers()
         self.is_closed = True
 

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -97,7 +97,6 @@ class _BatchedEnv(_EnvClass):
         create_env_fn (callable or list of callables): function (or list of functions) to be used for the environment
             creation;
         create_env_kwargs (dict or list of dicts, optional): kwargs to be used with the environments being created;
-        device (str, int, torch.device): device of the environment;
         action_keys (list of str, optional): list of keys that are to be considered policy-output. If the policy has it,
             the attribute policy.out_keys can be used.
             Providing the action_keys permit to select which keys to update after the policy is called, which can
@@ -118,6 +117,12 @@ class _BatchedEnv(_EnvClass):
         memmap (bool): whether or not the returned tensordict will be placed in memory map.
         policy_proof (callable, optional): if provided, it'll be used to get the list of
             tensors to return through the `step()` and `reset()` methods, such as `"hidden"` etc.
+        device (str, int, torch.device): for consistency, this argument is kept. However this
+            argument should not be passed, as the device will be inferred from the environments.
+            It is assumed that all environments will run on the same device as a common shared
+            tensordict will be used to pass data from process to process. The device can be
+            changed after instantiation using `env.to(device)`.
+
 
     """
 

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -392,7 +392,8 @@ class _BatchedEnv(_EnvClass):
         if not self.is_closed:
             warn(
                 "Casting an open environment to another device requires closing and re-opening it. "
-                 "This may have unexpected and unwanted effects (e.g. on seeding etc.)")
+                "This may have unexpected and unwanted effects (e.g. on seeding etc.)"
+            )
             # the tensordicts must be re-created on device
             super().to(device)
             self.close()

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -209,6 +209,7 @@ class _BatchedEnv(_EnvClass):
             self._observation_spec = dummy_env.observation_spec
             self._reward_spec = dummy_env.reward_spec
             self._dummy_env_str = str(dummy_env)
+            self.device = dummy_env.device
 
     @property
     def _dummy_env_context(self) -> _dummy_env_context:

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -72,7 +72,9 @@ class _dummy_env_context:
         self.device = device
 
     def __enter__(self):
-        self.dummy_env = self.fun(**self.kwargs).to(self.device)
+        self.dummy_env = self.fun(**self.kwargs)
+        if self.device is not None:
+            self.dummy_env.to(self.device)
         return self.dummy_env
 
     def __exit__(self, exc_type, exc_val, exc_tb):
@@ -223,7 +225,7 @@ class _BatchedEnv(_EnvClass):
     def _dummy_env_context(self) -> _dummy_env_context:
         """Returns a context manager that will create a dummy env and delete it afterwards"""
         return _dummy_env_context(
-            self._dummy_env_fun, self.create_env_kwargs[0], self.device
+            self._dummy_env_fun, self.create_env_kwargs[0], self._device
         )
 
     @property

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -219,7 +219,7 @@ class _BatchedEnv(_EnvClass):
             self._observation_spec = dummy_env.observation_spec
             self._reward_spec = dummy_env.reward_spec
             self._dummy_env_str = str(dummy_env)
-            self.device = dummy_env.device
+            self._device = dummy_env.device
 
     @property
     def _dummy_env_context(self) -> _dummy_env_context:

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -137,7 +137,7 @@ class _BatchedEnv(_EnvClass):
         shared_memory: bool = True,
         memmap: bool = False,
         policy_proof: Optional[Callable] = None,
-        device: Optional[DEVICE_TYPING] = "cpu",
+        device: Optional[DEVICE_TYPING] = None,
     ):
         if device is not None:
             raise ValueError(

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -384,6 +384,7 @@ class _BatchedEnv(_EnvClass):
         self._start_workers()
 
     def to(self, device: DEVICE_TYPING):
+        device = torch.device(device)
         self.device = device
         if not self.is_closed:
             # the tensordicts must be re-created on device

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import os
 from collections import OrderedDict
+from copy import deepcopy
 from logging import warn
 from multiprocessing import connection
 from typing import Callable, Optional, Sequence, Union, Any, List
@@ -141,7 +142,6 @@ class _BatchedEnv(_EnvClass):
         super().__init__(device=device)
         self.is_closed = True
 
-        create_env_kwargs = dict() if create_env_kwargs is None else create_env_kwargs
         if callable(create_env_fn):
             create_env_fn = [create_env_fn for _ in range(num_workers)]
         else:
@@ -150,8 +150,11 @@ class _BatchedEnv(_EnvClass):
                     f"num_workers and len(create_env_fn) mismatch, "
                     f"got {len(create_env_fn)} and {num_workers}"
                 )
+        create_env_kwargs = dict() if create_env_kwargs is None else create_env_kwargs
         if isinstance(create_env_kwargs, dict):
-            create_env_kwargs = [create_env_kwargs for _ in range(num_workers)]
+            create_env_kwargs = [
+                deepcopy(create_env_kwargs) for _ in range(num_workers)
+            ]
 
         self._dummy_env_instance = None
         try:

--- a/torchrl/modules/distributions/continuous.py
+++ b/torchrl/modules/distributions/continuous.py
@@ -101,7 +101,7 @@ class NormalParamWrapper(nn.Module):
     """A wrapper for normal distirbution parameters.
 
     Args:
-        operator (nn.Module): operator whose output will be transformed in location and scale parameters
+        operator (nn.Module): operator whose output will be transformed_in in location and scale parameters
         scale_mapping (str, optional): positive mapping function to be used with the std.
             default = "biased_softplus_1.0" (i.e. softplus map with bias such that fn(0.0) = 1.0)
             choices: "softplus", "exp", "relu", "biased_softplus_1";
@@ -473,7 +473,7 @@ class Delta(D.Distribution):
 
 class TanhDelta(D.TransformedDistribution):
     """
-    Implements a Tanh transformed Delta distribution.
+    Implements a Tanh transformed_in Delta distribution.
 
     Args:
         param (torch.Tensor): parameter of the delta distribution;

--- a/torchrl/modules/td_module/common.py
+++ b/torchrl/modules/td_module/common.py
@@ -225,7 +225,7 @@ class TDModule(nn.Module):
         return self._spec
 
     @spec.setter
-    def _spec_set(self, spec: TensorSpec) -> None:
+    def spec(self, spec: TensorSpec) -> None:
         if not isinstance(spec, TensorSpec):
             raise RuntimeError(
                 f"Trying to set an object of type {type(spec)} as a tensorspec."

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -261,7 +261,10 @@ class TDSequence(TDModule):
                     f"TDSequence.spec requires all specs to be valid TensorSpec objects. Got "
                     f"{type(layer.spec)}"
                 )
-            kwargs[out_key] = spec
+            if isinstance(spec, CompositeSpec):
+                kwargs.update(**spec._spec)
+            else:
+                kwargs[out_key] = spec
         return CompositeSpec(**kwargs)
 
     def make_functional_with_buffers(self, clone: bool = False):

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -256,7 +256,7 @@ class TDSequence(TDModule):
         for layer in self.module:
             out_key = layer.out_keys[0]
             spec = layer.spec
-            if not isinstance(spec, TensorSpec):
+            if spec is not None and not isinstance(spec, TensorSpec):
                 raise RuntimeError(
                     f"TDSequence.spec requires all specs to be valid TensorSpec objects. Got "
                     f"{type(layer.spec)}"

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -13,7 +13,6 @@ import torch
 from torch import nn, Tensor
 
 from torchrl.data import (
-    UnboundedContinuousTensorSpec,
     TensorSpec,
     CompositeSpec,
 )
@@ -262,7 +261,7 @@ class TDSequence(TDModule):
                     f"{type(layer.spec)}"
                 )
             if isinstance(spec, CompositeSpec):
-                kwargs.update(spec._spec)
+                kwargs.update(self._specs)
             else:
                 kwargs[out_key] = spec
         return CompositeSpec(**kwargs)

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -256,9 +256,6 @@ class TDSequence(TDModule):
         for layer in self.module:
             out_key = layer.out_keys[0]
             spec = layer.spec
-            if spec is None:
-                # By default, we consider that unspecified specs are unbounded.
-                spec = UnboundedContinuousTensorSpec()
             if not isinstance(spec, TensorSpec):
                 raise RuntimeError(
                     f"TDSequence.spec requires all specs to be valid TensorSpec objects. Got "

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -262,7 +262,7 @@ class TDSequence(TDModule):
                     f"{type(layer.spec)}"
                 )
             if isinstance(spec, CompositeSpec):
-                kwargs.update(**spec._spec)
+                kwargs.update(spec._spec)
             else:
                 kwargs[out_key] = spec
         return CompositeSpec(**kwargs)

--- a/torchrl/modules/td_module/sequence.py
+++ b/torchrl/modules/td_module/sequence.py
@@ -261,7 +261,7 @@ class TDSequence(TDModule):
                     f"{type(layer.spec)}"
                 )
             if isinstance(spec, CompositeSpec):
-                kwargs.update(self._specs)
+                kwargs.update(spec._specs)
             else:
                 kwargs[out_key] = spec
         return CompositeSpec(**kwargs)

--- a/torchrl/record/recorder.py
+++ b/torchrl/record/recorder.py
@@ -55,7 +55,7 @@ class VideoRecorder(ObservationTransform):
         except ImportError:
             raise Exception("moviepy not found, VideoRecorder cannot be created")
 
-    def _apply(self, observation: torch.Tensor) -> torch.Tensor:
+    def _apply_transform(self, observation: torch.Tensor) -> torch.Tensor:
         if not (observation.shape[-1] == 3 or observation.ndimension() == 2):
             raise RuntimeError(f"Invalid observation shape, got: {observation.shape}")
         observation_trsf = observation

--- a/torchrl/trainers/helpers/collectors.py
+++ b/torchrl/trainers/helpers/collectors.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from argparse import ArgumentParser, Namespace
-from typing import Callable, List, Optional, Type, Union
+from typing import Callable, List, Optional, Type, Union, Dict
 
 from torchrl.collectors.collectors import (
     _DataCollector,
@@ -242,7 +242,7 @@ def make_collector_offpolicy(
     make_env: Callable[[], _EnvClass],
     actor_model_explore: Union[TDModuleWrapper, ProbabilisticTensorDictModule],
     args: Namespace,
-    make_env_kwargs=None,
+    make_env_kwargs: Optional[Dict] = None,
 ) -> _DataCollector:
     """
     Returns a data collector for off-policy algorithms.
@@ -268,8 +268,10 @@ def make_collector_offpolicy(
         ms = None
 
     env_kwargs = {}
-    if make_env_kwargs is not None:
+    if make_env_kwargs is not None and isinstance(make_env_kwargs, dict):
         env_kwargs.update(make_env_kwargs)
+    elif make_env_kwargs is not None:
+        env_kwargs = make_env_kwargs
     args.collector_devices = (
         args.collector_devices
         if len(args.collector_devices) > 1
@@ -305,15 +307,17 @@ def make_collector_onpolicy(
     make_env: Callable[[], _EnvClass],
     actor_model_explore: Union[TDModuleWrapper, ProbabilisticTensorDictModule],
     args: Namespace,
-    make_env_kwargs=None,
+    make_env_kwargs: Optional[Dict] = None,
 ) -> _DataCollector:
     collector_helper = sync_sync_collector
 
     ms = None
 
     env_kwargs = {}
-    if make_env_kwargs is not None:
+    if make_env_kwargs is not None and isinstance(make_env_kwargs, dict):
         env_kwargs.update(make_env_kwargs)
+    elif make_env_kwargs is not None:
+        env_kwargs = make_env_kwargs
     args.collector_devices = (
         args.collector_devices
         if len(args.collector_devices) > 1


### PR DESCRIPTION
This PR:
- makes sure `env.to(device)` behaves as expected for regular envs, parallel, serial and transformed instances
- makes sure that environment creation on device behaves as expected
- allows tensordicts to be created empty but on device, such that all tensors are then placed on device afterwards