### PR TITLE
Add ellipsis indexing for TensorDict

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -14,7 +14,7 @@ from _utils_internal import get_available_devices
 from torch import multiprocessing as mp
 from torchrl.data import SavedTensorDict, TensorDict
 from torchrl.data.tensordict.tensordict import assert_allclose_td, LazyStackedTensorDict
-from torchrl.data.tensordict.utils import _getitem_batch_size, convert_ellipsis_to_idx
+from torchrl.data.tensordict.utils import _getitem_batch_size
 
 
 @pytest.mark.parametrize("device", get_available_devices())
@@ -814,55 +814,55 @@ class TestTensorDicts:
         td.set("numpy", r.numpy())
         torch.testing.assert_allclose(td.get("numpy"), r)
 
-    def test_getitem_ellipsis(self, td_name): 
+    def test_getitem_ellipsis(self, td_name):
         torch.manual_seed(1)
-        td = TensorDict({"a": torch.randn(1, 3, 4, 5, 6), "b": torch.randn(1, 3, 4, 5)}, batch_size=[1, 3, 4])
-        
-        actual_idx = [..., 
-                     (..., 0), 
-                     (0, ...), 
-                     (0, ..., 0)
-        ]
-        expected_idx = [(slice(None), slice(None), slice(None)),
-                        (slice(None), slice(None), 0), 
-                        (0, slice(None), slice(None)), 
-                        (0, slice(None), 0)
+        td = TensorDict(
+            {"a": torch.randn(1, 3, 4, 5, 6), "b": torch.randn(1, 3, 4, 5)},
+            batch_size=[1, 3, 4],
+        )
+
+        actual_idx = [..., (..., 0), (0, ...), (0, ..., 0)]
+        expected_idx = [
+            (slice(None), slice(None), slice(None)),
+            (slice(None), slice(None), 0),
+            (0, slice(None), slice(None)),
+            (0, slice(None), 0),
         ]
 
-        for i in range(len(actual_idx)): 
+        for i in range(len(actual_idx)):
             actual_td = td[actual_idx[i]]
             expected_td = td[expected_idx[i]]
 
-            for key in td.keys(): 
+            for key in td.keys():
                 actual_tensor = actual_td[key]
                 expected_tensor = expected_td[key]
 
                 assert actual_tensor.shape == expected_tensor.shape
                 torch.testing.assert_allclose(actual_tensor, expected_tensor)
 
-    def test_setitem_ellipsis(self, td_name): 
+    def test_setitem_ellipsis(self, td_name):
         torch.manual_seed(1)
-        td = TensorDict({"a": torch.randn(1, 3, 4, 5, 6), "b": torch.randn(1, 3, 4, 5)}, batch_size=[1, 3, 4])
-        
-        actual_idx = [..., 
-                     (..., 0), 
-                     (0, ...), 
-                     (0, ..., 0)
-        ]
-        expected_idx = [(slice(None), slice(None), slice(None)),
-                        (slice(None), slice(None), 0), 
-                        (0, slice(None), slice(None)), 
-                        (0, slice(None), 0)
+        td = TensorDict(
+            {"a": torch.randn(1, 3, 4, 5, 6), "b": torch.randn(1, 3, 4, 5)},
+            batch_size=[1, 3, 4],
+        )
+
+        actual_idx = [..., (..., 0), (0, ...), (0, ..., 0)]
+        expected_idx = [
+            (slice(None), slice(None), slice(None)),
+            (slice(None), slice(None), 0),
+            (0, slice(None), slice(None)),
+            (0, slice(None), 0),
         ]
 
-        for i in range(len(actual_idx)): 
+        for i in range(len(actual_idx)):
             idx = actual_idx[i]
             td_clone = td.clone()
             actual_td = td[idx].clone().zero_()
             td_clone[idx] = actual_td
 
-            for key in td.keys(): 
-                 assert (td[idx].get(key) == 0).all()
+            for key in td.keys():
+                assert (td[idx].get(key) == 0).all()
 
     @pytest.mark.parametrize("idx", [slice(1), torch.tensor([0]), torch.tensor([0, 1])])
     def test_setitem(self, td_name, idx):
@@ -871,7 +871,7 @@ class TestTensorDicts:
         if isinstance(idx, torch.Tensor) and idx.numel() > 1 and td.shape[0] == 1:
             pytest.mark.skip("cannot index tensor with desired index")
             return
-  
+
         td_clone = td[idx].clone().zero_()
         td[idx] = td_clone
         assert (td[idx].get("a") == 0).all()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -813,6 +813,19 @@ class TestTensorDicts:
         r = torch.randn_like(td.get("a"))
         td.set("numpy", r.numpy())
         torch.testing.assert_allclose(td.get("numpy"), r)
+    
+    @pytest.mark.parametrize("idx", [..., (..., 0), (0, ...), (0, ..., 0)])
+    def test_getitem_ellipsis(self, td_name, idx): 
+        torch.manual_seed(1)
+        td = getattr(self, td_name)
+        # print(td, "\n")
+        if idx is not Ellipsis and len(idx) > len(td.batch_size):
+            pytest.mark.skip("cannot index tensor with desired index")
+            return
+       
+        actual = td[idx]
+        #expected = 
+        # assert torch.testing.assert_allclose(actual, expected)
 
     @pytest.mark.parametrize("idx", [slice(1), torch.tensor([0]), torch.tensor([0, 1])])
     def test_setitem(self, td_name, idx):
@@ -821,7 +834,7 @@ class TestTensorDicts:
         if isinstance(idx, torch.Tensor) and idx.numel() > 1 and td.shape[0] == 1:
             pytest.mark.skip("cannot index tensor with desired index")
             return
-
+  
         td_clone = td[idx].clone().zero_()
         td[idx] = td_clone
         assert (td[idx].get("a") == 0).all()

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -13,7 +13,10 @@ import torch
 from _utils_internal import get_available_devices
 from torch import multiprocessing as mp
 from torchrl.data import SavedTensorDict, TensorDict
-from torchrl.data.tensordict.tensordict import SubTensorDict, UnsqueezedTensorDict, assert_allclose_td, LazyStackedTensorDict
+from torchrl.data.tensordict.tensordict import (
+    assert_allclose_td,
+    LazyStackedTensorDict,
+)
 from torchrl.data.tensordict.utils import _getitem_batch_size, convert_ellipsis_to_idx
 
 
@@ -430,6 +433,7 @@ def test_savedtensordict(device):
     torch.testing.assert_allclose(ss[1].get("a"), ss.get("a")[1])
     assert ss.get("a").device == device
 
+
 def test_convert_ellipsis_to_idx():
     torch.manual_seed(1)
     batch_size = [3, 4, 5, 6, 7]
@@ -447,38 +451,12 @@ def test_convert_ellipsis_to_idx():
     ]
 
     for i in range(len(ellipsis_idx)):
-        assert (
-            convert_ellipsis_to_idx(ellipsis_idx[i], batch_size) == expected_idx[i]
-        )
+        assert convert_ellipsis_to_idx(ellipsis_idx[i], batch_size) == expected_idx[i]
 
     for i in range(len(error_idx)):
         with pytest.raises(RuntimeError):
             _ = convert_ellipsis_to_idx(error_idx[i], batch_size)
-def td(td): 
-    return td
 
-def stacked_td(td):
-    return torch.stack([td for _ in range(2)], 0)
-
-def idx_td(td):
-    return td[0]
-
-def sub_td(td):
-    return td.get_sub_tensordict(0)
-
-def saved_td(td):
-    return SavedTensorDict(source=td)
-
-def unsqueezed_td(td):
-    return td.unsqueeze(0)
-
-def td_reset_bs(td):
-    td = td.unsqueeze(-1).to_tensordict()
-    td.batch_size = torch.Size([1, 3, 4, 5])
-    return td
-
-td_dict = {"td": td, "stacked_td": stacked_td, "sub_td": sub_td, "idx_td": idx_td, 
-           "saved_td": saved_td, "unsqueezed_td": unsqueezed_td, "td_reset_bs": td_reset_bs}
 
 @pytest.mark.parametrize(
     "td_name",
@@ -866,34 +844,23 @@ class TestTensorDicts:
     def test_getitem_ellipsis(self, td_name):
         torch.manual_seed(1)
 
-        td = TensorDict(
-                {"a": torch.randn(1, 3, 4, 5, 6, 6), "b": torch.randn(1, 3, 4, 5, 3)}, 
-                batch_size=[1, 3, 4, 5]
-            )
-        td = td_dict[td_name](td)
+        td = getattr(self, td_name)
         batch_size = len(td.batch_size)
-        
+
         actual_idx = [..., (..., 0), (0, ...), (0, ..., 0)]
         expected_idx = [
             (slice(None),) * batch_size,
-            (slice(None),) * (batch_size-1) + (0,),
-            (0,) + (slice(None),) * (batch_size-1),
-            (0,) + (slice(None),) * (batch_size-2) + (0,),
+            (slice(None),) * (batch_size - 1) + (0,),
+            (0,) + (slice(None),) * (batch_size - 1),
+            (0,) + (slice(None),) * (batch_size - 2) + (0,),
         ]
 
         for i in range(len(actual_idx)):
-            
-            actual_idx[3] = (0,) + (slice(None),) * (batch_size-2) + (0,)
-            if td_name == "stacked_td": 
-                print("START")
-                print(td_name)
-                print("\n")
-                print(td.batch_size, td[actual_idx[i]].batch_size, td[expected_idx[i]].batch_size)
-                print(actual_idx[i])
-                print("\n")
-                print("END")
             actual_td = td[actual_idx[i]]
             expected_td = td[expected_idx[i]]
+            assert expected_td.shape == _getitem_batch_size(
+                td.batch_size, convert_ellipsis_to_idx(actual_idx[i], td.batch_size)
+            )
 
             for key in td.keys():
                 actual_tensor = actual_td[key]
@@ -903,29 +870,15 @@ class TestTensorDicts:
                 torch.testing.assert_allclose(actual_tensor, expected_tensor)
 
     def test_setitem_ellipsis(self, td_name):
-        # if td_name == "stacked_td":
-        #     pytest.set_trace()
         torch.manual_seed(1)
-     
-        td = TensorDict(
-                {"a": torch.randn(1, 3, 4, 5, 6, 6), "b": torch.randn(1, 3, 4, 5, 3)}, 
-                batch_size=[1, 3, 4, 5]
-            )
-        td = td_dict[td_name](td)
+        td = getattr(self, td_name)
 
-        actual_idx = [(0, ..., 0)]
-        # print("NEW")
+        actual_idx = [..., (..., 0), (0, ...), (0, ..., 0)]
+
         for i in range(len(actual_idx)):
             idx = actual_idx[i]
             td_clone = td.clone()
             actual_td = td_clone[idx].clone().zero_()
-            # print("TD CLONE")
-            # print(td_clone)
-            # print(actual_td)
-            # print(td_clone[idx])
-            # if td_name == "stacked_td": 
-                # print("HERE")
-                # print(td_clone[0, slice(None), slice(None), slice(None), 0])
             td_clone[idx] = actual_td
 
             for key in td_clone.keys():

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2861,11 +2861,9 @@ class LazyStackedTensorDict(_TensorDict):
                 stack_dim=new_stack_dim,
             )
         elif isinstance(item, tuple):
-            print("HERE")
             _sub_item = tuple(
                 _item for i, _item in enumerate(item) if i == self.stack_dim
             )
-            print(self.stack_dim, item, _sub_item)
             if len(_sub_item):
                 tensordicts = self.tensordicts[_sub_item[0]]
                 if isinstance(tensordicts, _TensorDict):
@@ -2881,7 +2879,6 @@ class LazyStackedTensorDict(_TensorDict):
             new_stack_dim = self.stack_dim - sum(
                 [isinstance(_item, Number) for _item in item[: self.stack_dim]]
             )
-            # print(torch.stack(list(tensordicts), dim=new_stack_dim))
             return torch.stack(list(tensordicts), dim=new_stack_dim)
         else:
             raise NotImplementedError(

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2861,9 +2861,11 @@ class LazyStackedTensorDict(_TensorDict):
                 stack_dim=new_stack_dim,
             )
         elif isinstance(item, tuple):
+            print("HERE")
             _sub_item = tuple(
                 _item for i, _item in enumerate(item) if i == self.stack_dim
             )
+            print(self.stack_dim, item, _sub_item)
             if len(_sub_item):
                 tensordicts = self.tensordicts[_sub_item[0]]
                 if isinstance(tensordicts, _TensorDict):
@@ -2879,6 +2881,7 @@ class LazyStackedTensorDict(_TensorDict):
             new_stack_dim = self.stack_dim - sum(
                 [isinstance(_item, Number) for _item in item[: self.stack_dim]]
             )
+            # print(torch.stack(list(tensordicts), dim=new_stack_dim))
             return torch.stack(list(tensordicts), dim=new_stack_dim)
         else:
             raise NotImplementedError(

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -36,7 +36,11 @@ import torch
 
 from torchrl.data.tensordict.memmap import MemmapTensor
 from torchrl.data.tensordict.metatensor import MetaTensor
-from torchrl.data.tensordict.utils import _getitem_batch_size, _sub_index,  convert_ellipsis_to_idx
+from torchrl.data.tensordict.utils import (
+    _getitem_batch_size,
+    _sub_index,
+    convert_ellipsis_to_idx,
+)
 from torchrl.data.utils import DEVICE_TYPING, expand_as_right, INDEX_TYPING
 
 __all__ = [
@@ -1265,7 +1269,7 @@ dtype=torch.float32)},
             idx = (idx,)
         elif isinstance(idx, torch.Tensor) and idx.dtype == torch.bool:
             return self.masked_select(idx)
-     
+
         contiguous_input = (int, slice)
         return_simple_view = isinstance(idx, contiguous_input) or (
             isinstance(idx, tuple)
@@ -1276,9 +1280,9 @@ dtype=torch.float32)},
                 "indexing a tensordict with td.batch_dims==0 is not permitted"
             )
 
-        if idx is Ellipsis or (isinstance(idx, tuple) and Ellipsis in idx): 
+        if idx is Ellipsis or (isinstance(idx, tuple) and Ellipsis in idx):
             idx = convert_ellipsis_to_idx(idx, self.batch_size)
-    
+
         if return_simple_view and not self.is_memmap():
             return TensorDict(
                 source={key: item[idx] for key, item in self.items()},
@@ -1290,7 +1294,7 @@ dtype=torch.float32)},
         return self.get_sub_tensordict(idx)
 
     def __setitem__(self, index: INDEX_TYPING, value: _TensorDict) -> None:
-        if index is Ellipsis or (isinstance(index, tuple) and Ellipsis in index): 
+        if index is Ellipsis or (isinstance(index, tuple) and Ellipsis in index):
             index = convert_ellipsis_to_idx(index, self.batch_size)
         if isinstance(index, str):
             self.set(index, value, inplace=False)
@@ -3258,9 +3262,9 @@ class SavedTensorDict(_TensorDict):
         return super().__reduce__(*args, **kwargs)
 
     def __getitem__(self, idx: INDEX_TYPING) -> _TensorDict:
-        if idx is Ellipsis or (isinstance(idx, tuple) and Ellipsis in idx): 
+        if idx is Ellipsis or (isinstance(idx, tuple) and Ellipsis in idx):
             idx = convert_ellipsis_to_idx(idx, self.batch_size)
-       
+
         if isinstance(idx, str):
             return self.get(idx)
         elif isinstance(idx, Number):

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2815,7 +2815,7 @@ class LazyStackedTensorDict(_TensorDict):
         )
 
     def __getitem__(self, item: INDEX_TYPING) -> _TensorDict:
-        if item is Ellipsis or (isinstance(item, tuple) and Ellipsis in item): 
+        if item is Ellipsis or (isinstance(item, tuple) and Ellipsis in item):
             item = convert_ellipsis_to_idx(item, self.batch_size)
 
         if isinstance(item, str):
@@ -3260,7 +3260,7 @@ class SavedTensorDict(_TensorDict):
     def __getitem__(self, idx: INDEX_TYPING) -> _TensorDict:
         if idx is Ellipsis or (isinstance(idx, tuple) and Ellipsis in idx): 
             idx = convert_ellipsis_to_idx(idx, self.batch_size)
-
+       
         if isinstance(idx, str):
             return self.get(idx)
         elif isinstance(idx, Number):

--- a/torchrl/data/tensordict/utils.py
+++ b/torchrl/data/tensordict/utils.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from numbers import Number
+from typing import Tuple, List, Union
 
 import torch
 
@@ -84,17 +85,17 @@ def _getitem_batch_size(
     return torch.Size(bs)
 
 
-def convert_ellipsis_to_idx(idx: tuple, batch_size: list):
+def convert_ellipsis_to_idx(idx: Union[Tuple, Ellipsis], batch_size: List[int]):
     """
     Given an index containing an ellipsis or just an ellipsis, converts any ellipsis to slice(None)
     Example: idx = (..., 0), batch_size = [1,2,3] -> new_index = (slice(None), slice(None), 0)
 
     Args:
-        idx: Input index
-        batch_size: Shape of tensor to be indexed
+        idx (Tuple, Ellipsis): Input index
+        batch_size (List): Shape of tensor to be indexed
 
     Returns:
-        new_index: Output index
+        new_index (Tuple): Output index
     """
     new_index = ()
     num_dims = len(batch_size)

--- a/torchrl/data/tensordict/utils.py
+++ b/torchrl/data/tensordict/utils.py
@@ -6,6 +6,9 @@
 from __future__ import annotations
 
 from numbers import Number
+from pickle import NONE
+from tracemalloc import start
+from typing import Tuple
 
 import torch
 
@@ -82,3 +85,59 @@ def _getitem_batch_size(
     list_iter_bs = list(iter_bs)
     bs += list_iter_bs
     return torch.Size(bs)
+
+def convert_ellipsis_to_idx(
+    idx: tuple, 
+    batch_size: list
+): 
+    """
+    Given an index containing an ellipsis, converts any ellipsis to slice(None)
+    Example: idx = (..., 0), batch_size = [1,2,3] -> new_index = (slice(None), slice(None), 0)
+
+    Args:
+        idx: Input index
+        batch_size: Shape of tensor to be indexed
+
+    Returns:
+        new_index: Output index
+    """
+    new_index = ()
+    num_dims = len(batch_size)
+    
+    if idx is Ellipsis: 
+        idx = (..., )
+    if num_dims < len(idx): 
+        raise RuntimeError (
+            f"Not enough dimensions in TensorDict for index provided."
+        )
+
+    start_pos, after_ellipsis_length = None, 0
+    for i, item in enumerate(idx): 
+        if item is Ellipsis: 
+            if start_pos: 
+                raise RuntimeError(
+                    f"An index can only have one ellipsis at most."
+                )
+            else: 
+                start_pos = i
+        if item is not Ellipsis and start_pos is not None: 
+            after_ellipsis_length += 1
+
+    before_ellipsis_length = start_pos
+    ellipsis_length = num_dims - after_ellipsis_length - before_ellipsis_length
+   
+    new_index += idx[:start_pos]
+
+    ellipsis_start = start_pos
+    ellipsis_end = start_pos+ellipsis_length
+    new_index += (slice(None),) * (ellipsis_end-ellipsis_start)
+
+    new_index += idx[start_pos+1: start_pos+1+after_ellipsis_length]
+   
+    if len(new_index) != num_dims: 
+        raise RuntimeError(
+            f"The new index {new_index} is incompatible with the dimensions of the batch size {num_dims}."
+        )
+
+
+    return new_index

--- a/torchrl/data/tensordict/utils.py
+++ b/torchrl/data/tensordict/utils.py
@@ -4,11 +4,12 @@
 # LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
+from doctest import ELLIPSIS
 
 from numbers import Number
 from pickle import NONE
 from tracemalloc import start
-from typing import Tuple
+from typing import Union
 
 import torch
 

--- a/torchrl/data/tensordict/utils.py
+++ b/torchrl/data/tensordict/utils.py
@@ -91,11 +91,11 @@ def convert_ellipsis_to_idx(idx: Union[Tuple, Ellipsis], batch_size: List[int]):
     Example: idx = (..., 0), batch_size = [1,2,3] -> new_index = (slice(None), slice(None), 0)
 
     Args:
-        idx (Tuple, Ellipsis): Input index
-        batch_size (List): Shape of tensor to be indexed
+        idx (tuple, Ellipsis): Input index
+        batch_size (list): Shape of tensor to be indexed
 
     Returns:
-        new_index (Tuple): Output index
+        new_index (tuple): Output index
     """
     new_index = ()
     num_dims = len(batch_size)

--- a/torchrl/data/tensordict/utils.py
+++ b/torchrl/data/tensordict/utils.py
@@ -107,7 +107,7 @@ def convert_ellipsis_to_idx(idx: tuple, batch_size: list):
     start_pos, after_ellipsis_length = None, 0
     for i, item in enumerate(idx):
         if item is Ellipsis:
-            if start_pos:
+            if start_pos is not None:
                 raise RuntimeError("An index can only have one ellipsis at most.")
             else:
                 start_pos = i


### PR DESCRIPTION
Implemented ellipsis indexing by creating function convert_ellipsis_to_idx to convert ellipsis into slice(None), depending on batch size of TensorDict. 
For example, for td = TensorDict({'a': torch.zeros(3, 4, 5), 'b': torch.ones(3, 4, 5, 6)}, batch_size=[3, 4, 5])
tensordict[..., 0] becomes tensordict[(slice(None), slice(None), 0)]
Added tests for __getitem__ and __setitem__ into tests/test_tensordict.py. 