### PR TITLE
Change the default trainer scheduler to None

### DIFF
--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -275,7 +275,7 @@ def parser_trainer_args(parser: ArgumentParser) -> ArgumentParser:
         "--lr_scheduler",
         "--lr-scheduler",
         type=str,
-        default="cosine",
+        default="",
         choices=["cosine", ""],
         help="LR scheduler.",
     )


### PR DESCRIPTION
Changing the default schedule to be consistent with regular rainbow dqn.