### PR TITLE
Implement unittests for MemmapTensor.

### DIFF
--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -10,9 +10,8 @@ import tempfile
 import numpy as np
 import pytest
 import torch
-from torchrl.data.tensordict.memmap import MemmapTensor
-
 from _utils_internal import get_available_devices
+from torchrl.data.tensordict.memmap import MemmapTensor
 
 
 def test_memmap_type():
@@ -37,12 +36,24 @@ def test_grad():
         MemmapTensor(t + 1)
 
 
-@pytest.mark.parametrize("dtype", [torch.half, torch.float, torch.double,
-                                   torch.int, torch.uint8, torch.long, torch.bool])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.half,
+        torch.float,
+        torch.double,
+        torch.int,
+        torch.uint8,
+        torch.long,
+        torch.bool,
+    ],
+)
 @pytest.mark.parametrize(
     "shape",
     [
-        [2, ],
+        [
+            2,
+        ],
         [1, 2],
     ],
 )
@@ -155,14 +166,14 @@ def test_memmap_same_device_as_tensor(device):
 
 @pytest.mark.parametrize("device", get_available_devices())
 def test_memmap_create_on_same_device(device):
-    """Test if the device arg for MemmapTensor init is respected.
-    """
+    """Test if the device arg for MemmapTensor init is respected."""
     m = MemmapTensor([3, 4], device=device)
     assert m.device == torch.device(device)
 
 
-@pytest.mark.parametrize("value", [torch.zeros([3, 4]),
-                                   MemmapTensor(torch.zeros([3, 4]))])
+@pytest.mark.parametrize(
+    "value", [torch.zeros([3, 4]), MemmapTensor(torch.zeros([3, 4]))]
+)
 def test_memmap_zero_value(value):
     """
     Test if all entries are zeros when MemmapTensor is created with size.

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -167,7 +167,7 @@ def test_memmap_same_device_as_tensor(device):
                 + "but found at least two devices",
             ):
                 assert torch.all(m + torch.ones([3, 4], device=other_device) == 1)
-        m.to(other_device)
+        m = m.to(other_device)
         assert m.device == torch.device(other_device)
 
 
@@ -186,7 +186,7 @@ def test_memmap_zero_value(device, value):
     """
     Test if all entries are zeros when MemmapTensor is created with size.
     """
-    value.to(device)
+    value = value.to(device)
     expected_memmap_tensor = MemmapTensor(value)
     m1 = MemmapTensor([3, 4], device=device)
     assert m1.shape == (3, 4)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -182,20 +182,17 @@ def test_memmap_create_on_same_device(device):
 @pytest.mark.parametrize(
     "value", [torch.zeros([3, 4]), MemmapTensor(torch.zeros([3, 4]))]
 )
-def test_memmap_zero_value(device, value):
+@pytest.mark.parametrize("shape", [[3, 4], [[3, 4]]])
+def test_memmap_zero_value(device, value, shape):
     """
     Test if all entries are zeros when MemmapTensor is created with size.
     """
     value = value.to(device)
     expected_memmap_tensor = MemmapTensor(value)
-    m1 = MemmapTensor([3, 4], device=device)
-    assert m1.shape == (3, 4)
-    assert torch.all(m1 == expected_memmap_tensor)
-    assert torch.all(m1 + torch.ones([3, 4], device=device) == 1)
-    m2 = MemmapTensor(3, 4, device=device)
-    assert m2.shape == (3, 4)
-    assert torch.all(m2 == expected_memmap_tensor)
-    assert torch.all(m2 + torch.ones([3, 4], device=device) == 1)
+    m = MemmapTensor(*shape, device=device)
+    assert m.shape == (3, 4)
+    assert torch.all(m == expected_memmap_tensor)
+    assert torch.all(m + torch.ones([3, 4], device=device) == 1)
 
 
 if __name__ == "__main__":

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -188,11 +188,11 @@ def test_memmap_zero_value(device, value):
     """
     value.to(device)
     expected_memmap_tensor = MemmapTensor(value)
-    m1 = MemmapTensor([3, 4])
+    m1 = MemmapTensor([3, 4], device=device)
     assert m1.shape == (3, 4)
     assert torch.all(m1 == expected_memmap_tensor)
     assert torch.all(m1 + torch.ones([3, 4], device=device) == 1)
-    m2 = MemmapTensor(3, 4)
+    m2 = MemmapTensor(3, 4, device=device)
     assert m2.shape == (3, 4)
     assert torch.all(m2 == expected_memmap_tensor)
     assert torch.all(m2 + torch.ones([3, 4], device=device) == 1)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -164,7 +164,7 @@ def test_memmap_same_device_as_tensor(device):
             with pytest.raises(
                 RuntimeError,
                 match="Expected all tensors to be on the same device, "
-                + "but found at least two devices .*",
+                + "but found at least two devices",
             ):
                 assert torch.all(m + torch.ones([3, 4], device=other_device) == 1)
         m.to(other_device)

--- a/test/test_memmap.py
+++ b/test/test_memmap.py
@@ -191,11 +191,11 @@ def test_memmap_zero_value(device, value):
     m1 = MemmapTensor([3, 4])
     assert m1.shape == (3, 4)
     assert torch.all(m1 == expected_memmap_tensor)
-    assert torch.all(m1 + torch.ones([3, 4]) == 1)
+    assert torch.all(m1 + torch.ones([3, 4], device=device) == 1)
     m2 = MemmapTensor(3, 4)
     assert m2.shape == (3, 4)
     assert torch.all(m2 == expected_memmap_tensor)
-    assert torch.all(m2 + torch.ones([3, 4]) == 1)
+    assert torch.all(m2 + torch.ones([3, 4], device=device) == 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Added a test if the created MemmapTensor is on the same device as the input tensor. 
- Added a test if device is correct when .to(device) is called.
- Added a test if the device arg for MemmapTensor init is respected.
- Added a test if all entries are zeros when MemmapTensor is created with size.
- Added a test if MemmapTensor can be created with a given data type and shape.

This PR closes #221.
