### PR TITLE
[Feature] custom info_dict reader methods

### DIFF
--- a/torchrl/envs/__init__.py
+++ b/torchrl/envs/__init__.py
@@ -8,3 +8,4 @@ from .libs import *
 from .vec_env import *
 from .transforms import *
 from .env_creator import *
+from .gym_like import *


### PR DESCRIPTION
Proposes a `set_info_dict_reader` method for gym-like environments that'll read the info dictionary and write down the values on a `TensorDict` in a way defined by the user.
This will allow users to use `GymWrapper` and `GymEnv` without effort in cases where the info dictionary is weird and unpredictable.

cc @BoboBananas 