### PR TITLE
Empty TensorDict population in loops

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1597,7 +1597,7 @@ def test_filling_empty_tensordict(device, td_type, update):
     elif td_type == "squeeze":
         assert td._source["a"].shape == torch.Size([16, 1, 10])
     elif td_type == "stack":
-        assert (td[-1] == other_td).all()
+        assert (td[-1] == other_td.to(device)).all()
 
 
 if __name__ == "__main__":

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1299,8 +1299,14 @@ dtype=torch.float32)},
                     f"(batch_size = {self.batch_size}, index={index}), "
                     f"which differs from the source batch size {value.batch_size}"
                 )
+            keys = set(self.keys())
+            if not all(key in keys for key in value.keys()):
+                subtd = self.get_sub_tensordict(index)
             for key, item in value.items():
-                self.set_at_(key, item, index)
+                if key in keys:
+                    self.set_at_(key, item, index)
+                else:
+                    subtd.set(key, item)
 
     def __delitem__(self, index: INDEX_TYPING) -> _TensorDict:
         if isinstance(index, str):
@@ -2246,9 +2252,10 @@ torch.Size([3, 2])
     ) -> _TensorDict:
         if self.is_locked:
             raise RuntimeError("Cannot modify immutable TensorDict")
-        if inplace and key in self.keys():
+        keys = set(self.keys())
+        if inplace and key in keys:
             return self.set_(key, tensor)
-        elif key in self.keys():
+        elif key in keys:
             raise RuntimeError(
                 "Calling `SubTensorDict.set(key, value, inplace=False)` is prohibited for existing tensors. "
                 "Consider calling `SubTensorDict.set_(...)` or cloning your tensordict first."

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2272,7 +2272,7 @@ torch.Size([3, 2])
             device=self.device,
         )
 
-        if self.is_shared():
+        if self.is_shared() and self.device == torch.device("cpu"):
             tensor_expand.share_memory_()
         elif self.is_memmap():
             tensor_expand = MemmapTensor(tensor_expand)


### PR DESCRIPTION
Allows for TensorDict creation like this

```python
>>> td = TensorDict({}, batch_size=[100])
>>> 
>>> for i in range(100):
>>>     td[i] = TensorDict({"a": torch.randn(10), "b": torch.zeros(1)}, [])
>>> 
>>> print(td)
TensorDict(
    fields={
        a: Tensor(torch.Size([100, 10]), dtype=torch.float32),
        b: Tensor(torch.Size([100, 1]), dtype=torch.float32)},
    batch_size=torch.Size([100]),
    device=cpu,
    is_shared=False)
```

The tensordict is populated with zero-valued key-value pairs when first initialized, hence creating an empty tensor that is to be populated.

cc @BoboBananas 