### PR TITLE
[Feature] Nested tensordicts

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -486,6 +486,7 @@ TD_BATCH_SIZE = 4
         "memmap_td",
         "unsqueezed_td",
         "td_reset_bs",
+        "nested_td",
     ],
 )
 class TestTensorDicts:
@@ -496,6 +497,18 @@ class TestTensorDicts:
                 "a": torch.randn(4, 3, 2, 1, 5),
                 "b": torch.randn(4, 3, 2, 1, 10),
                 "c": torch.randint(10, (4, 3, 2, 1, 3)),
+            },
+            batch_size=[4, 3, 2, 1],
+        )
+
+    @property
+    def nested_td(self):
+        return TensorDict(
+            source={
+                "a": torch.randn(4, 3, 2, 1, 5),
+                "b": torch.randn(4, 3, 2, 1, 10),
+                "c": torch.randint(10, (4, 3, 2, 1, 3)),
+                "my_nested_td": TensorDict({"inner": torch.randn(4, 3, 2, 1, 2)}, [4, 3, 2, 1]),
             },
             batch_size=[4, 3, 2, 1],
         )
@@ -593,8 +606,10 @@ class TestTensorDicts:
         td = getattr(self, td_name)
         td2 = td.exclude("a")
         assert td2 is not td
-        assert len(list(td2.keys())) == 2 and "a" not in td2.keys()
-        assert len(list(td2.clone().keys())) == 2 and "a" not in td2.clone().keys()
+        assert len(list(td2.keys())) == len(list(td.keys()))-1 and \
+               "a" not in td2.keys()
+        assert len(list(td2.clone().keys())) == len(list(td.keys()))-1 and \
+               "a" not in td2.clone().keys()
 
         td2 = td.exclude("a", inplace=True)
         assert td2 is td
@@ -1026,6 +1041,19 @@ class TestTensorDicts:
         assert td.get("a").requires_grad
         assert td._get_meta("a").requires_grad
 
+    def test_nested_td_emptyshape(self, td_name):
+        td = getattr(self, td_name)
+        tdin = TensorDict({"inner": torch.randn(*td.shape, 1)}, [])
+        td["inner_td"] = tdin
+        # tdin.batch_size = td.batch_size
+        print(td["inner_td"].to_tensordict(), tdin)
+        assert (td["inner_td"] == tdin).all()
+
+    def test_nested_td(self, td_name):
+        td = getattr(self, td_name)
+        tdin = TensorDict({"inner": torch.randn(td.shape)}, td.shape)
+        td.set("inner_td", tdin)
+        assert (td["inner_td"] == tdin).all()
 
 @pytest.mark.parametrize(
     "td_name",

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1060,6 +1060,10 @@ class TestTensorDicts:
         td.set("inner_td", tdin)
         assert (td["inner_td"] == tdin).all()
 
+    def test_repr(self, td_name):
+        td = getattr(self, td_name)
+        _ = str(td)
+
 
 @pytest.mark.parametrize(
     "td_name",

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1130,8 +1130,7 @@ class TestTensorDicts:
         td = getattr(self, td_name)
         tdin = TensorDict({"inner": torch.randn(*td.shape, 1)}, [])
         td["inner_td"] = tdin
-        # tdin.batch_size = td.batch_size
-        print(td["inner_td"].to_tensordict(), tdin)
+        tdin.batch_size = td.batch_size
         assert (td["inner_td"] == tdin).all()
 
     def test_nested_td(self, td_name):

--- a/torchrl/data/tensordict/memmap.py
+++ b/torchrl/data/tensordict/memmap.py
@@ -382,10 +382,8 @@ class MemmapTensor(object):
         return self
 
     def __del__(self) -> None:
-        # if hasattr(self, "filename"):
         if "_has_ownership" in self.__dir__() and self._has_ownership:
             os.unlink(self.filename)
-            # self.file.close()
 
     def __eq__(self, other: Any) -> torch.Tensor:
         if not isinstance(other, (MemmapTensor, torch.Tensor, float, int, np.ndarray)):

--- a/torchrl/data/tensordict/metatensor.py
+++ b/torchrl/data/tensordict/metatensor.py
@@ -71,7 +71,7 @@ class MetaTensor:
         _is_memmap: Optional[bool] = None,
         _is_tensordict: Optional[bool] = None,
     ):
-        _repr = None
+        _repr_tensordict = None
         if len(shape) == 1 and not isinstance(shape[0], (Number,)):
             tensor = shape[0]
             shape = tensor.shape
@@ -86,7 +86,7 @@ class MetaTensor:
                 dtype = tensor.dtype
             else:
                 dtype = None
-                _repr = str(tensor)
+                _repr_tensordict = str(tensor)
 
             requires_grad = (
                 tensor.requires_grad
@@ -105,7 +105,7 @@ class MetaTensor:
         self._is_shared = bool(_is_shared)
         self._is_memmap = bool(_is_memmap)
         self._is_tensordict = bool(_is_tensordict)
-        self._repr = _repr
+        self._repr_tensordict = _repr_tensordict
         if _is_tensordict:
             name = "TensorDict"
         elif _is_memmap:
@@ -115,6 +115,12 @@ class MetaTensor:
         else:
             name = "Tensor"
         self.class_name = name
+
+    def get_repr(self):
+        if self.is_tensordict():
+            return self._repr_tensordict
+        else:
+            return f"{self.class_name}({self.shape}, dtype={self.dtype})"
 
     def memmap_(self) -> MetaTensor:
         """Changes the storage of the MetaTensor to memmap.

--- a/torchrl/data/tensordict/metatensor.py
+++ b/torchrl/data/tensordict/metatensor.py
@@ -69,8 +69,8 @@ class MetaTensor:
         requires_grad: bool = False,
         _is_shared: Optional[bool] = None,
         _is_memmap: Optional[bool] = None,
+        _is_tensordict: Optional[bool] = None,
     ):
-        _is_tensordict = False
         _repr = None
         if len(shape) == 1 and not isinstance(shape[0], (Number,)):
             tensor = shape[0]
@@ -80,11 +80,11 @@ class MetaTensor:
             if _is_memmap is None:
                 _is_memmap = isinstance(tensor, MemmapTensor)
             device = tensor.device if not tensor.is_meta else device
+            if _is_tensordict is None:
+                _is_tensordict = not isinstance(tensor, (MemmapTensor, torch.Tensor))
             if isinstance(tensor, (MemmapTensor, torch.Tensor)):
                 dtype = tensor.dtype
             else:
-                _is_tensordict = True
-                tensordict_name = tensor.__class__.__name__
                 dtype = None
                 _repr = str(tensor)
 
@@ -104,10 +104,10 @@ class MetaTensor:
         self._numel = np.prod(shape)
         self._is_shared = bool(_is_shared)
         self._is_memmap = bool(_is_memmap)
-        self._is_tensordict = _is_tensordict
+        self._is_tensordict = bool(_is_tensordict)
         self._repr = _repr
         if _is_tensordict:
-            name = tensordict_name
+            name = "TensorDict"
         elif _is_memmap:
             name = "MemmapTensor"
         elif _is_shared:
@@ -168,6 +168,7 @@ class MetaTensor:
             requires_grad=self.requires_grad,
             _is_shared=self.is_shared(),
             _is_memmap=self.is_memmap(),
+            _is_tensordict=self.is_tensordict(),
         )
 
     def _to_meta(self) -> torch.Tensor:
@@ -182,6 +183,7 @@ class MetaTensor:
             requires_grad=self.requires_grad,
             _is_shared=self.is_shared(),
             _is_memmap=self.is_memmap(),
+            _is_tensordict=self.is_tensordict(),
         )
 
     @classmethod
@@ -271,6 +273,7 @@ class MetaTensor:
             requires_grad=self.requires_grad,
             _is_shared=self.is_shared(),
             _is_memmap=self.is_memmap(),
+            _is_tensordict=self.is_tensordict(),
         )
 
 

--- a/torchrl/data/tensordict/metatensor.py
+++ b/torchrl/data/tensordict/metatensor.py
@@ -70,7 +70,8 @@ class MetaTensor:
         _is_shared: Optional[bool] = None,
         _is_memmap: Optional[bool] = None,
     ):
-
+        _is_tensordict = False
+        _repr = None
         if len(shape) == 1 and not isinstance(shape[0], (Number,)):
             tensor = shape[0]
             shape = tensor.shape
@@ -79,12 +80,20 @@ class MetaTensor:
             if _is_memmap is None:
                 _is_memmap = isinstance(tensor, MemmapTensor)
             device = tensor.device if not tensor.is_meta else device
-            dtype = tensor.dtype
+            if isinstance(tensor, (MemmapTensor, torch.Tensor)):
+                dtype = tensor.dtype
+            else:
+                _is_tensordict = True
+                tensordict_name = tensor.__class__.__name__
+                dtype = None
+                _repr = str(tensor)
+
             requires_grad = (
                 tensor.requires_grad
                 if isinstance(tensor, torch.Tensor)
                 else requires_grad
             )
+
         if not isinstance(shape, torch.Size):
             shape = torch.Size(shape)
         self.shape = shape
@@ -95,7 +104,11 @@ class MetaTensor:
         self._numel = np.prod(shape)
         self._is_shared = bool(_is_shared)
         self._is_memmap = bool(_is_memmap)
-        if _is_memmap:
+        self._is_tensordict = _is_tensordict
+        self._repr = _repr
+        if _is_tensordict:
+            name = tensordict_name
+        elif _is_memmap:
             name = "MemmapTensor"
         elif _is_shared:
             name = "SharedTensor"
@@ -131,6 +144,9 @@ class MetaTensor:
 
     def is_memmap(self) -> bool:
         return self._is_memmap
+
+    def is_tensordict(self) -> bool:
+        return self._is_tensordict
 
     def numel(self) -> int:
         return self._numel

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -3769,14 +3769,7 @@ def _td_fields(td: _TensorDict) -> str:
     return indent(
         "\n"
         + ",\n".join(
-            sorted(
-                [
-                    f"{key}: {item.class_name}({item.shape}, dtype={item.dtype})"
-                    if not item.is_tensordict()
-                    else f"{key}: {item._repr}"
-                    for key, item in td.items_meta()
-                ]
-            )
+            sorted([f"{key}: {item.get_repr()}" for key, item in td.items_meta()])
         ),
         4 * " ",
     )

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1,4 +1,4 @@
-#pad_size, value Copyright (c) Meta Platforms, Inc. and affiliates.
+# pad_size, value Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1,4 +1,4 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
+#pad_size, value Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
@@ -1138,28 +1138,61 @@ dtype=torch.float32)},
 
     def permute(
         self,
-        *dims: int,
+        *dims_list: int,
+        dims=None,
     ) -> _TensorDict:
         """Returns a view of a tensordict with the batch dimensions permuted according to dims
 
         Args:
-            *dims (int): the new ordering of the batch dims of the tensordict.
+            *dims_list (int): the new ordering of the batch dims of the tensordict. Alternatively,
+                a single iterable of integers can be provided.
+            dims (list of int): alternative way of calling permute(...).
 
         Returns:
             a new tensordict with the batch dimensions in the desired order.
 
         Examples:
-            >>> TODO
+            >>> tensordict = TensorDict({"a": torch.randn(3, 4, 5)}, [3, 4])
+            >>> print(tensordict.permute([1, 0]))
+            PermutedTensorDict(
+                source=TensorDict(
+                    fields={
+                        a: Tensor(torch.Size([3, 4, 5]), dtype=torch.float32)},
+                    batch_size=torch.Size([3, 4]),
+                    device=cpu,
+                    is_shared=False),
+                op=permute(dims=[1, 0]))
+            >>> print(tensordict.permute(1, 0))
+            PermutedTensorDict(
+                source=TensorDict(
+                    fields={
+                        a: Tensor(torch.Size([3, 4, 5]), dtype=torch.float32)},
+                    batch_size=torch.Size([3, 4]),
+                    device=cpu,
+                    is_shared=False),
+                op=permute(dims=[1, 0]))
+            >>> print(tensordict.permute(dims=[1, 0]))
+            PermutedTensorDict(
+                source=TensorDict(
+                    fields={
+                        a: Tensor(torch.Size([3, 4, 5]), dtype=torch.float32)},
+                    batch_size=torch.Size([3, 4]),
+                    device=cpu,
+                    is_shared=False),
+                op=permute(dims=[1, 0]))
         """
-
-        if len(dims) != len(self.shape):
+        if len(dims_list) == 0:
+            dims_list = dims
+        elif len(dims_list) == 1 and not isinstance(dims_list[0], int):
+            dims_list = dims_list[0]
+        if len(dims_list) != len(self.shape):
             raise RuntimeError(
-                f"number of dims don't match in permute (got {len(dims)}, expected {len(self.shape)}"
+                f"number of dims don't match in permute (got {len(dims_list)}, expected {len(self.shape)}"
             )
 
         min_dim, max_dim = -self.batch_dims, self.batch_dims - 1
         seen = [False for dim in range(max_dim + 1)]
-        for idx in dims:
+        for idx in dims_list:
             if idx < min_dim or idx > max_dim:
                 raise IndexError(
                     f"dimension out of range (expected to be in range of [{min_dim}, {max_dim}], but got {idx})"
@@ -1172,8 +1205,8 @@ dtype=torch.float32)},
             source=self,
             custom_op="permute",
             inv_op="permute",
-            custom_op_kwargs={"dims": dims},
-            inv_op_kwargs={"dims": dims},
+            custom_op_kwargs={"dims": dims_list},
+            inv_op_kwargs={"dims": dims_list},
         )
 
     def __repr__(self) -> str:
@@ -2203,13 +2236,16 @@ def pad(tensordict: _TensorDict, pad_size: Sequence[int], value: float = 0.0):
     for i in range(0, len(reverse_pad), 2):
         reverse_pad[i], reverse_pad[i + 1] = reverse_pad[i + 1], reverse_pad[i]
 
-    out = TensorDict({}, new_batch_size)
+    out = TensorDict({}, new_batch_size, device=tensordict.device)
     for key, tensor in tensordict.items():
         cur_pad = reverse_pad
         if len(pad_size) < len(tensor.shape) * 2:
             cur_pad = [0] * (len(tensor.shape) * 2 - len(pad_size)) + reverse_pad
 
-        padded = torch.nn.functional.pad(tensordict[key], cur_pad, value=value)
+        if isinstance(tensor, _TensorDict):
+            padded = pad(tensor, pad_size, value)
+        else:
+            padded = torch.nn.functional.pad(tensor, cur_pad, value=value)
         out.set(key, padded)
 
     return out
@@ -3579,15 +3615,9 @@ class _CustomOpTensorDict(_TensorDict):
             check_device=False,
             check_tensor_shape=True,
         )
-        if isinstance(proc_value, _TensorDict):
-            print("pre")
-            print(proc_value)
         proc_value = getattr(proc_value, self.inv_op)(
             **self._update_inv_op_kwargs(proc_value)
         )
-        if isinstance(proc_value, _TensorDict):
-            print("post", self.inv_op, self._update_inv_op_kwargs(proc_value))
-            print(proc_value)
         self._source.set(key, proc_value, **kwargs)
         return self
 

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1647,7 +1647,9 @@ class TensorDict(_TensorDict):
     def pin_memory(self) -> _TensorDict:
         if self.device == torch.device("cpu"):
             for key, value in self.items():
-                if value.dtype in (torch.half, torch.float, torch.double):
+                if isinstance(value, _TensorDict) or (
+                    value.dtype in (torch.half, torch.float, torch.double)
+                ):
                     self.set(key, value.pin_memory(), inplace=False)
         return self
 

--- a/torchrl/data/utils.py
+++ b/torchrl/data/utils.py
@@ -62,8 +62,8 @@ class CloudpickleWrapper(object):
 
 
 def expand_as_right(
-    tensor: Union[torch.Tensor, "MemmapTensor"],
-    dest: Union[torch.Tensor, "MemmapTensor"],
+    tensor: Union[torch.Tensor, "MemmapTensor", "_TensorDict"],
+    dest: Union[torch.Tensor, "MemmapTensor", "_TensorDict"],
 ):
     """Expand a tensor on the right to match another tensor shape.
     Args:
@@ -94,7 +94,7 @@ def expand_as_right(
         )
     for _ in range(dest.ndimension() - tensor.ndimension()):
         tensor = tensor.unsqueeze(-1)
-    return tensor.expand_as(dest)
+    return tensor.expand(dest.shape)
 
 
 def expand_right(


### PR DESCRIPTION
- [X] tests
- [x] flatten (do we need that?)  => #264 
- [x] nested composite spec -> test rand and encode => #265 
- [x] indexing using tuples `td[key1, key2]" => #262

```python
from torchrl.data import TensorDict
import torch

td1 = TensorDict({"a": torch.randn(4, 1)}, [4])
td2 = TensorDict({"b": torch.randn(4, 1), "td": td1}, [4])

print(td2)

td1 = TensorDict({"a": torch.randn(4, 1)}, [])
td2 = TensorDict({"b": torch.randn(4, 1), "td": td1}, [4])

print(td2)

td1 = TensorDict({"a": torch.randn(4, 1)}, [])
td2 = TensorDict({"b": torch.randn(4, 1)}, [4])
td2["td"] = td1

print(td2)

td1 = TensorDict({"a": torch.randn(4, 1)}, [])
td2b = TensorDict({"b": torch.randn(4, 1)}, [4])
td2b["td"] = td1

td2b[:] = td2

print(td2)

```
