### PR TITLE
[BugFix]: gym 0.25 with from_pixels=True requires render_mode tp be specified

### DIFF
--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -85,9 +85,9 @@ def test_gym(env_name, frame_skip, from_pixels, pixels_only):
         frame_skip = 1
     else:
         if from_pixels:
-            base_env = gym.make(env_name)
-        else:
             base_env = gym.make(env_name, render_mode="single_rgb_array")
+        else:
+            base_env = gym.make(env_name)
 
     if from_pixels and not _is_from_pixels(base_env):
         base_env = PixelObservationWrapper(base_env, pixels_only=pixels_only)

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -84,7 +84,10 @@ def test_gym(env_name, frame_skip, from_pixels, pixels_only):
         base_env = gym.make(env_name, frameskip=frame_skip)
         frame_skip = 1
     else:
-        base_env = gym.make(env_name)
+        if from_pixels:
+            base_env = gym.make(env_name)
+        else:
+            base_env = gym.make(env_name, render_mode="single_rgb_array")
 
     if from_pixels and not _is_from_pixels(base_env):
         base_env = PixelObservationWrapper(base_env, pixels_only=pixels_only)

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -135,6 +135,8 @@ class GymWrapper(GymLikeEnv):
     def __init__(self, env=None, **kwargs):
         if env is not None:
             kwargs["env"] = env
+        if kwargs.get("from_pixels", False):
+            kwargs["render_mode"] = "single_rgb_array"
         self._seed_calls_reset = None
         super().__init__(**kwargs)
 

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -135,8 +135,6 @@ class GymWrapper(GymLikeEnv):
     def __init__(self, env=None, **kwargs):
         if env is not None:
             kwargs["env"] = env
-        if kwargs.get("from_pixels", False):
-            kwargs["render_mode"] = "single_rgb_array"
         self._seed_calls_reset = None
         super().__init__(**kwargs)
 
@@ -270,6 +268,8 @@ class GymEnv(GymWrapper):
         from_pixels = kwargs.get("from_pixels", False)
         if "from_pixels" in kwargs:
             del kwargs["from_pixels"]
+            kwargs["render_mode"] = "single_rgb_array"
+
         pixels_only = kwargs.get("pixels_only", True)
         if "pixels_only" in kwargs:
             del kwargs["pixels_only"]

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -266,9 +266,10 @@ class GymEnv(GymWrapper):
                 f" {self.git_url}"
             )
         from_pixels = kwargs.get("from_pixels", False)
+        if from_pixels:
+            kwargs["render_mode"] = "single_rgb_array"
         if "from_pixels" in kwargs:
             del kwargs["from_pixels"]
-            kwargs["render_mode"] = "single_rgb_array"
 
         pixels_only = kwargs.get("pixels_only", True)
         if "pixels_only" in kwargs:

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -277,7 +277,7 @@ class GymEnv(GymWrapper):
         try:
             with warnings.catch_warnings(record=True) as w:
                 env = self.lib.make(env_name, frameskip=self.frame_skip, **kwargs)
-                if len(w) and "frameskip" in str(w[-1].message):
+                if any("frameskip" in str(_w.message) for _w in w):
                     raise TypeError("unexpected keyword argument 'frameskip'")
             self.wrapper_frame_skip = 1
         except TypeError as err:


### PR DESCRIPTION
## Description

Gym introduced a BC-breaking change in their rendering API.
See issue [here](https://github.com/openai/gym/issues/2972) and PR [here](https://github.com/openai/gym/pull/2671).

## Motivation and Context

Fix this bug by making sure `render_mode` is always specified.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)
