### PR TITLE
[Feature] Truly invertible tensordict permutation of dimensions

### DIFF
--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1299,13 +1299,14 @@ dtype=torch.float32)},
                 raise RuntimeError("repeated dim in permute")
             seen[idx] = True
 
-        return PermutedTensorDict(
+        result = PermutedTensorDict(
             source=self,
             custom_op="permute",
             inv_op="permute",
             custom_op_kwargs={"dims": dims_list},
             inv_op_kwargs={"dims": dims_list},
         )
+        return result
 
     def __repr__(self) -> str:
         fields = _td_fields(self)


### PR DESCRIPTION
## Description

Inverse operations on Tensordicts can return the original data. This is currently not the case for tensordict.permute.

We need to return the original tensordict when calling tensordict.permute(a, b, c) we get an instance of a PermutedTensorDict and if we call again the same method with the same parameters in the resulting PermutedTensorDict 

`assert tensordict.permute(dims_list, dim).permute(dims_list, dim) is tensordict`

## Motivation and Context

`close #278`

- [ ] I have raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
