### PR TITLE
[Doc] MacOs M1 troubleshooting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,13 @@ python setup.py develop
 ```
 in your shell.
 
+If the generation of this artifact in MacOs M1 doesn't work correctly or in the execution the message 
+`(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))` appears, then try
+
+```
+ARCHFLAGS="-arch arm64" python setup.py develop
+```
+
 ## Formatting your code
 **Type annotation** 
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ and functorch
 pip install "git+https://github.com/pytorch/functorch.git"
 ```
 
+If the generation of this artifact in MacOs M1 doesn't work correctly or in the execution the message 
+`(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))` appears, then try
+
+```
+ARCHFLAGS="-arch arm64" pip install "git+https://github.com/pytorch/functorch.git"
+```
+
 **Torchrl**
 
 You can install the latest release by using
@@ -112,6 +119,13 @@ Go to the directory where you have cloned the torchrl repo and install it
 ```
 cd /path/to/torchrl/
 python setup.py develop
+```
+
+If the generation of this artifact in MacOs M1 doesn't work correctly or in the execution the message 
+`(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))` appears, then try
+
+```
+ARCHFLAGS="-arch arm64" python setup.py develop
 ```
 
 To run a quick sanity check, leave that directory (e.g. by executing `cd ~/`) 

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1295,13 +1295,14 @@ dtype=torch.float32)},
                 raise RuntimeError("repeated dim in permute")
             seen[idx] = True
 
-        return PermutedTensorDict(
+        result = PermutedTensorDict(
             source=self,
             custom_op="permute",
             inv_op="permute",
             custom_op_kwargs={"dims": dims_list},
             inv_op_kwargs={"dims": dims_list},
         )
+        return result
 
     def __repr__(self) -> str:
         fields = _td_fields(self)

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1295,14 +1295,13 @@ dtype=torch.float32)},
                 raise RuntimeError("repeated dim in permute")
             seen[idx] = True
 
-        result = PermutedTensorDict(
+        return PermutedTensorDict(
             source=self,
             custom_op="permute",
             inv_op="permute",
             custom_op_kwargs={"dims": dims_list},
             inv_op_kwargs={"dims": dims_list},
         )
-        return result
 
     def __repr__(self) -> str:
         fields = _td_fields(self)


### PR DESCRIPTION
## Description

Updated documentation to troubleshooting in case the generation of the artifact in MacOs M1 machines have incompatibility problems with the architecture because it is being generated for x86_64 architecture instead of arm64 architecture.

## Motivation and Context

After some errors in the execution of the generated artifact, showing an error with this message `(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))`, we realized that we need to define the target architecture before the generation of the artifact in MacOs M1.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
