### PR TITLE
[Feature] Transforms: `Compose.insert` and `TransformedEnv.insert_transform`

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 import argparse
+from copy import copy
 
 import pytest
 import torch
@@ -932,6 +933,111 @@ class TestTransforms:
         obs_spec = env.observation_spec
         obs_spec = obs_spec[key]
         assert obs_spec.shape[-1] == 4 * env.base_env.observation_spec[key].shape[-1]
+
+    def test_insert(self):
+
+        env = ContinuousActionVecMockEnv()
+        obs_spec = env.observation_spec
+        key = list(obs_spec.keys())[0]
+        env = TransformedEnv(env)
+
+        _ = env.action_spec
+        _ = env.observation_spec
+        _ = env.reward_spec
+
+        assert env._action_spec is not None
+        assert env._observation_spec is not None
+        assert env._reward_spec is not None
+
+        env.insert_transform(0, CatFrames(N=4, cat_dim=-1, keys_in=[key]))
+
+        assert env._action_spec is None
+        assert env._observation_spec is None
+        assert env._reward_spec is None
+
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 1
+        obs_spec = env.observation_spec
+        obs_spec = obs_spec[key]
+        assert obs_spec.shape[-1] == 4 * env.base_env.observation_spec[key].shape[-1]
+
+        env.insert_transform(1, FiniteTensorDictCheck())
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 2
+        assert isinstance(env.transform[-1], FiniteTensorDictCheck)
+        assert isinstance(env.transform[0], CatFrames)
+
+        env.insert_transform(0, NoopResetEnv())
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 3
+        assert isinstance(env.transform[0], NoopResetEnv)
+        assert isinstance(env.transform[1], CatFrames)
+        assert isinstance(env.transform[2], FiniteTensorDictCheck)
+
+        env.insert_transform(2, NoopResetEnv())
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 4
+        assert isinstance(env.transform[0], NoopResetEnv)
+        assert isinstance(env.transform[1], CatFrames)
+        assert isinstance(env.transform[2], NoopResetEnv)
+        assert isinstance(env.transform[3], FiniteTensorDictCheck)
+
+        env.insert_transform(-3, PinMemoryTransform())
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 5
+        assert isinstance(env.transform[0], NoopResetEnv)
+        assert isinstance(env.transform[1], PinMemoryTransform)
+        assert isinstance(env.transform[2], CatFrames)
+        assert isinstance(env.transform[3], NoopResetEnv)
+        assert isinstance(env.transform[4], FiniteTensorDictCheck)
+        assert env._action_spec is None
+        assert env._observation_spec is None
+        assert env._reward_spec is None
+
+        env.insert_transform(-5, CatFrames(N=4, cat_dim=-1, keys_in=[key]))
+        assert isinstance(env.transform, Compose)
+        assert len(env.transform) == 6
+
+        assert isinstance(env.transform[0], CatFrames)
+        assert isinstance(env.transform[1], NoopResetEnv)
+        assert isinstance(env.transform[2], PinMemoryTransform)
+        assert isinstance(env.transform[3], CatFrames)
+        assert isinstance(env.transform[4], NoopResetEnv)
+        assert isinstance(env.transform[5], FiniteTensorDictCheck)
+        assert env._action_spec is None
+        assert env._observation_spec is None
+        assert env._reward_spec is None
+
+        _ = copy(env.action_spec)
+        _ = copy(env.observation_spec)
+        _ = copy(env.reward_spec)
+
+        try:
+            env.insert_transform(-7, FiniteTensorDictCheck())
+            assert 1 == 6
+        except ValueError as ve:
+            assert len(env.transform) == 6
+            assert env._action_spec is not None
+            assert env._observation_spec is not None
+            assert env._reward_spec is not None
+
+        try:
+            env.insert_transform(7, FiniteTensorDictCheck())
+            assert 1 == 6
+        except ValueError as ve:
+            assert len(env.transform) == 6
+            assert env._action_spec is not None
+            assert env._observation_spec is not None
+            assert env._reward_spec is not None
+
+        try:
+            env.insert_transform(4, "ffff")
+            assert 1 == 6
+        except ValueError as ve:
+            assert len(env.transform) == 6
+            assert env._action_spec is not None
+            assert env._observation_spec is not None
+            assert env._reward_spec is not None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Added 2 functions for #281 Feature Request. 
- TransformedEnv::insert_transform
- Compose::insert

it support negative indexes as well. Index must be between [-len(list), len(list)]

+ added test_insert. 
Test plan:
1. insert in empty 
2. insert at front, back, the medial 
3. insert with negative indexes. (2 cases: at the medial, and at front) 
4. checking "empty_cache"
5. checking exceptions for index out of bound (neg , pos) and wrong type of input args.
6. keeping metadata after exceptions 



## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

- [x ] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ x] My change requires a change to the documentation.
- [ x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
