### PR TITLE
[BugFix] Fix a build warning, setuptools/distutils import order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from setuptools import setup, find_packages
 import distutils.command.clean
 import glob
 import os
@@ -11,7 +12,6 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from setuptools import setup, find_packages
 from torch.utils.cpp_extension import (
     CppExtension,
     BuildExtension,


### PR DESCRIPTION

when building locally I was getting the below build warning. Changing import order seems to fix it.
```
/Users/bvaughan/anaconda3/lib/python3.7/site-packages/setuptools/distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  "Distutils was imported before Setuptools. This usage is discouraged "
```
