### PR TITLE
Adding additional checks to `TensorDict.view` to minimise new object creation

### DIFF
--- a/torchrl/data/tensordict/memmap.py
+++ b/torchrl/data/tensordict/memmap.py
@@ -52,7 +52,7 @@ class MemmapTensor(object):
     and remote workers that have access to
     a common storage, and as such it supports serialization and
     deserialization. It is possible to choose if the ownership is
-    transferred upon serialization / deserialization: If owenership is not
+    transferred upon serialization / deserialization: If ownership is not
     transferred (transfer_ownership=False, default), then the process where
     the MemmapTensor was created will be responsible of clearing it once it
     gets out of scope (in that process). Otherwise, the process that


### PR DESCRIPTION
## Description

Currently running the following code results in a double-nested ViewedTensorDict, even though the final size - `[-1, 4]` is equivalent to the original size of `[3, 4]`. 

```python
>>> td = TensorDict({"a": torch.rand(3, 4)}, [3, 4])

>>> td.view(-1).view(-1, 4)
ViewedTensorDict(
    source=ViewedTensorDict(
        source=TensorDict({"a": ...}, batch_size=torch.Size([3, 4]), ...),
        op=view(size=torch.Size([-1]))
    ),
    op=view(size=torch.Size([-1, 4]))
)
```

This PR adds additional checks so that we can detect these cases, and handle them appropriately - i.e. return the original TensorDict.

In addition to that - running `TensorDict.view` with the shape of the tensordict being viewed - no matter whether it includes negative numbers or not (e.g. `[3, 4]`, `[3, -1]`, etc) - will now return `self` instead of a `ViewedTensorDict` with original shape as well.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
