### PR TITLE
[BugFix]: Safe state normalization when std=0

### DIFF
--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -371,7 +371,9 @@ def get_stats_random_rollout(
         s = td_stats.get(key).std().clamp_min(1e-5)
     else:
         m = td_stats.get(key).mean(dim=0)
-        s = td_stats.get(key).std(dim=0).clamp_min(1e-5)
+        s = td_stats.get(key).std(dim=0)
+    m[s == 0] = 0.0
+    s[s == 0] = 1.0
 
     print(
         f"stats computed for {td_stats.numel()} steps. Got: \n"


### PR DESCRIPTION
When the standard deviation of a state value is 0, we used to clamp at 1e-5. If the state variance then becomes non-null, its value will likely explore.
We make sure that this does not happen by setting the loc to 0 and scale to 1.0 whenever the std is 0.