### PR TITLE
[BugFix]: Tensor map for subtensordict.set_

### DIFF
--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -670,7 +670,11 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
         else:
             stacked_td = tensordicts
         idx = super().extend(tensordicts, priorities)
-        stacked_td.set("index", idx, inplace=True)
+        stacked_td.set(
+            "index",
+            torch.tensor(idx, dtype=torch.int, device=stacked_td.device),
+            inplace=True,
+        )
         return idx
 
     def update_priority(self, tensordict: TensorDictBase) -> None:

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -2766,6 +2766,9 @@ torch.Size([3, 2])
                     f"tensor.shape={tensor.shape[:self.batch_dims]} and "
                     f"self.batch_size={self.batch_size} mismatch"
                 )
+        tensor = self._process_tensor(
+            tensor, check_device=False, check_tensor_shape=False
+        )
         self._source.set_at_(key, tensor, self.idx)
         if key in self._dict_meta:
             self._dict_meta[key].requires_grad = tensor.requires_grad


### PR DESCRIPTION
Solves an error with the replay buffer when updating the indices of a stored tensordict.