### PR TITLE
[Setup]: Exclude tutorials from wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ def _main():
         long_description_content_type="text/markdown",
         license="BSD",
         # Package info
-        packages=find_packages(exclude=("test",)),
+        packages=find_packages(exclude=("test", "tutorials")),
         ext_modules=get_extensions(),
         cmdclass={
             "build_ext": BuildExtension.with_options(no_python_abi_suffix=True),


### PR DESCRIPTION
Exclude the tutorials folder from the setup.py installation