### PR TITLE
[BugFix]: make training example gracefully exit

### DIFF
--- a/examples/ddpg/ddpg.py
+++ b/examples/ddpg/ddpg.py
@@ -205,7 +205,7 @@ def main(cfg: "DictConfig"):
     print(f"init seed: {cfg.seed}, final seed: {final_seed}")
 
     trainer.train()
-    return (logger.log_dir, trainer._log_dict, trainer.state_dict())
+    return (logger.log_dir, trainer._log_dict)
 
 
 if __name__ == "__main__":

--- a/examples/dqn/dqn.py
+++ b/examples/dqn/dqn.py
@@ -175,7 +175,7 @@ def main(cfg: "DictConfig"):
     print(f"init seed: {cfg.seed}, final seed: {final_seed}")
 
     trainer.train()
-    return (logger.log_dir, trainer._log_dict, trainer.state_dict())
+    return (logger.log_dir, trainer._log_dict)
 
 
 if __name__ == "__main__":

--- a/examples/ppo/ppo.py
+++ b/examples/ppo/ppo.py
@@ -177,7 +177,7 @@ def main(cfg: "DictConfig"):
     print(f"init seed: {cfg.seed}, final seed: {final_seed}")
 
     trainer.train()
-    return (logger.log_dir, trainer._log_dict, trainer.state_dict())
+    return (logger.log_dir, trainer._log_dict)
 
 
 if __name__ == "__main__":

--- a/examples/redq/redq.py
+++ b/examples/redq/redq.py
@@ -205,7 +205,7 @@ def main(cfg: "DictConfig"):
     print(f"init seed: {cfg.seed}, final seed: {final_seed}")
 
     trainer.train()
-    return (logger.log_dir, trainer._log_dict, trainer.state_dict())
+    return (logger.log_dir, trainer._log_dict)
 
 
 if __name__ == "__main__":

--- a/examples/sac/sac.py
+++ b/examples/sac/sac.py
@@ -201,7 +201,7 @@ def main(cfg: "DictConfig"):
     print(f"init seed: {cfg.seed}, final seed: {final_seed}")
 
     trainer.train()
-    return (logger.log_dir, trainer._log_dict, trainer.state_dict())
+    return (logger.log_dir, trainer._log_dict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Training examples try to return a `state_dict` of an object that has been stopped. We prevent this to happen by not returning this `state_dict`.