### PR TITLE
[BugFix] Fixed compose which ignored inv_transforms of child

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -551,12 +551,11 @@ class Compose(Transform):
         for t in self.transforms:
             tensordict = t(tensordict)
         return tensordict
-    
+
     def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
         for t in self.transforms[::-1]:
             tensordict = t.inv(tensordict)
         return tensordict
-    
 
     def transform_action_spec(self, action_spec: TensorSpec) -> TensorSpec:
         for t in self.transforms:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -551,6 +551,12 @@ class Compose(Transform):
         for t in self.transforms:
             tensordict = t(tensordict)
         return tensordict
+    
+    def _inv_call(self, tensordict: TensorDictBase) -> TensorDictBase:
+        for t in self.transforms[::-1]:
+            tensordict = t.inv(tensordict)
+        return tensordict
+    
 
     def transform_action_spec(self, action_spec: TensorSpec) -> TensorSpec:
         for t in self.transforms:


### PR DESCRIPTION
## Description

Fixing Compose which ignored child inv_calls
## Motivation and Context

Compose.inv wasnt actually doing anything when called when ignoring child inv_transforms. This PR fix it.


## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
