### PR TITLE
[Refactor] Change to_tensordict to clone when called

### DIFF
--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -861,7 +861,7 @@ dtype=torch.float32)},
             a new TensorDict object containing the same values.
 
         """
-        return self.to(
+        return self.clone().to(
             TensorDict,
             batch_size=self.batch_size,
             device=self.device,
@@ -2788,7 +2788,7 @@ torch.Size([3, 2])
             if isinstance(self, dest):
                 return self
             return dest(
-                source=self.clone(),
+                source=self,
             )
         elif isinstance(dest, (torch.device, str, int)):
             dest = torch.device(dest)


### PR DESCRIPTION
## Description

This PR aims to change tensordict.to_tensordict behaviour. The idea is to make a clone each time the method is called.
## Motivation and Context

The motivation behind it is clone the tensordict when performing .to_tensordict. 

- [ ] I have raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ ] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
