### PR TITLE
[BugFix] Add lock to vec norm transform

### DIFF
--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -483,8 +483,8 @@ def test_collector_vecnorm_envcreator():
 
     s = c.state_dict()
 
-    td1 = s["worker0"]["env_state_dict"]["worker3"]["_extra_state"].clone()
-    td2 = s["worker1"]["env_state_dict"]["worker0"]["_extra_state"].clone()
+    td1 = s["worker0"]["env_state_dict"]["worker3"]["_extra_state"]["td"].clone()
+    td2 = s["worker1"]["env_state_dict"]["worker0"]["_extra_state"]["td"].clone()
     assert (td1 == td2).all()
 
     next(c_iter)
@@ -492,8 +492,8 @@ def test_collector_vecnorm_envcreator():
 
     s = c.state_dict()
 
-    td3 = s["worker0"]["env_state_dict"]["worker3"]["_extra_state"].clone()
-    td4 = s["worker1"]["env_state_dict"]["worker0"]["_extra_state"].clone()
+    td3 = s["worker0"]["env_state_dict"]["worker3"]["_extra_state"]["td"].clone()
+    td4 = s["worker1"]["env_state_dict"]["worker0"]["_extra_state"]["td"].clone()
     assert (td3 == td4).all()
     assert (td1 != td4).any()
 

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -46,120 +46,6 @@ from torchrl.envs.transforms.transforms import (
 TIMEOUT = 10.0
 
 
-def _test_vecnorm_subproc(idx, shared_lock, queue_out: mp.Queue, queue_in: mp.Queue):
-    td = queue_in.get(timeout=TIMEOUT)
-    if _has_gym:
-        env = GymEnv("Pendulum-v1")
-    else:
-        env = ContinuousActionVecMockEnv()
-    t = VecNorm(shared_td=td, lock=shared_lock)
-    env = TransformedEnv(env, t)
-    env.set_seed(1000 + idx)
-    tensordict = env.reset()
-    for _ in range(10):
-        env.rand_step(tensordict)
-    queue_out.put(True)
-    msg = queue_in.get(timeout=TIMEOUT)
-    assert msg == "all_done"
-    obs_sum = t._td.get("next_observation_sum").clone()
-    obs_ssq = t._td.get("next_observation_ssq").clone()
-    obs_count = t._td.get("next_observation_ssq").clone()
-    reward_sum = t._td.get("reward_sum").clone()
-    reward_ssq = t._td.get("reward_ssq").clone()
-    reward_count = t._td.get("reward_ssq").clone()
-
-    td_out = TensorDict(
-        {
-            "obs_sum": obs_sum,
-            "obs_ssq": obs_ssq,
-            "obs_count": obs_count,
-            "reward_sum": reward_sum,
-            "reward_ssq": reward_ssq,
-            "reward_count": reward_count,
-        },
-        [],
-    ).share_memory_()
-    queue_out.put(td_out)
-    msg = queue_in.get(timeout=TIMEOUT)
-    assert msg == "all_done"
-    queue_in.close()
-    queue_out.close()
-    del queue_in, queue_out
-
-
-@pytest.mark.parametrize("nprc", [2, 5])
-def test_vecnorm_parallel(nprc):
-    queues = []
-    prcs = []
-    shared_lock = mp.Lock()
-    if _has_gym:
-        td = VecNorm.build_td_for_shared_vecnorm(GymEnv("Pendulum-v1"))
-    else:
-        td = VecNorm.build_td_for_shared_vecnorm(
-            ContinuousActionVecMockEnv(),
-        )
-    for idx in range(nprc):
-        prc_queue_in = mp.Queue(1)
-        prc_queue_out = mp.Queue(1)
-        p = mp.Process(
-            target=_test_vecnorm_subproc,
-            args=(
-                idx,
-                shared_lock,
-                prc_queue_in,
-                prc_queue_out,
-            ),
-        )
-        p.start()
-        prc_queue_out.put(td)
-        prcs.append(p)
-        queues.append((prc_queue_in, prc_queue_out))
-
-    dones = [queue[0].get(timeout=TIMEOUT) for queue in queues]
-    assert all(dones)
-    msg = "all_done"
-    for idx in range(nprc):
-        queues[idx][1].put(msg)
-
-    obs_sum = td.get("next_observation_sum").clone()
-    obs_ssq = td.get("next_observation_ssq").clone()
-    obs_count = td.get("next_observation_ssq").clone()
-    reward_sum = td.get("reward_sum").clone()
-    reward_ssq = td.get("reward_ssq").clone()
-    reward_count = td.get("reward_ssq").clone()
-
-    for idx in range(nprc):
-        td_out = queues[idx][0].get(timeout=TIMEOUT)
-        _obs_sum = td_out.get("obs_sum")
-        _obs_ssq = td_out.get("obs_ssq")
-        _obs_count = td_out.get("obs_count")
-        _reward_sum = td_out.get("reward_sum")
-        _reward_ssq = td_out.get("reward_ssq")
-        _reward_count = td_out.get("reward_count")
-        assert (obs_sum == _obs_sum).all()
-        assert (obs_ssq == _obs_ssq).all()
-        assert (obs_count == _obs_count).all()
-        assert (reward_sum == _reward_sum).all()
-        assert (reward_ssq == _reward_ssq).all()
-        assert (reward_count == _reward_count).all()
-
-        obs_sum, obs_ssq, obs_count, reward_sum, reward_ssq, reward_count = (
-            _obs_sum,
-            _obs_ssq,
-            _obs_count,
-            _reward_sum,
-            _reward_ssq,
-            _reward_count,
-        )
-
-    msg = "all_done"
-    for idx in range(nprc):
-        queues[idx][1].put(msg)
-    del queues
-    for p in prcs:
-        p.join()
-
-
 def _test_vecnorm_subproc_auto(idx, make_env, queue_out: mp.Queue, queue_in: mp.Queue):
     env = make_env()
     env.set_seed(1000 + idx)
@@ -189,22 +75,15 @@ def _test_vecnorm_subproc_auto(idx, make_env, queue_out: mp.Queue, queue_in: mp.
 @pytest.mark.parametrize("nprc", [2, 5])
 def test_vecnorm_parallel_auto(nprc):
 
-    # note:  it's critical to create the lock outside of the lambda
-    #       otherwise there will be a seperate lock per process
-    shared_lock = mp.Lock()
     queues = []
     prcs = []
     if _has_gym:
         make_env = EnvCreator(
-            lambda: TransformedEnv(
-                GymEnv("Pendulum-v1"), VecNorm(decay=1.0, lock=shared_lock)
-            )
+            lambda: TransformedEnv(GymEnv("Pendulum-v1"), VecNorm(decay=1.0))
         )
     else:
         make_env = EnvCreator(
-            lambda: TransformedEnv(
-                ContinuousActionVecMockEnv(), VecNorm(decay=1.0, lock=shared_lock)
-            )
+            lambda: TransformedEnv(ContinuousActionVecMockEnv(), VecNorm(decay=1.0))
         )
 
     for idx in range(nprc):
@@ -293,19 +172,12 @@ def _run_parallelenv(parallel_env, queue_in, queue_out):
 
 
 def test_parallelenv_vecnorm():
-    # using mp.Manager.Lock here as the test necessitates it being passed between processes
-    m = mp.Manager()
-    shared_lock = m.Lock()
     if _has_gym:
-        make_env = EnvCreator(
-            lambda: TransformedEnv(GymEnv("Pendulum-v1"), VecNorm(lock=shared_lock))
-        )
+        make_env = EnvCreator(lambda: TransformedEnv(GymEnv("Pendulum-v1"), VecNorm()))
         env_input_keys = None
     else:
         make_env = EnvCreator(
-            lambda: TransformedEnv(
-                ContinuousActionVecMockEnv(), VecNorm(lock=shared_lock)
-            )
+            lambda: TransformedEnv(ContinuousActionVecMockEnv(), VecNorm())
         )
         env_input_keys = ["action", ContinuousActionVecMockEnv._out_key]
     parallel_env = ParallelEnv(3, make_env, env_input_keys=env_input_keys)

--- a/torchrl/collectors/collectors.py
+++ b/torchrl/collectors/collectors.py
@@ -72,6 +72,8 @@ def recursive_map_to_cpu(dictionary: OrderedDict) -> OrderedDict:
             k: recursive_map_to_cpu(item)
             if isinstance(item, OrderedDict)
             else item.cpu()
+            if isinstance(item, torch.Tensor)
+            else item
             for k, item in dictionary.items()
         }
     )


### PR DESCRIPTION
## Description

Implemented Lock support in VecNorm
The lock parameter is optional, to avoid overhead if no locking is needed, if provided the VecNorm will acquire it to make the updates multiprocessing safe

Updated tests:
test_vecnorm_parallel
test_vecnorm_parallel_auto
test_parallelenv_vecnorm

As lock is stored in extra state, fixed up some locations in code making assumptions of the layout/contents of the state_dicts, this code seemed internal or part of tests so I don't think the change should be breaking in general

## Motivation and Context

close #312

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
