### PR TITLE
[BugFix] Representation of indexed nested tensordict

### DIFF
--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -1542,7 +1542,11 @@ dtype=torch.float32)},
         # if return_simple_view and not self.is_memmap():
         return TensorDict(
             source={key: item[idx] for key, item in self.items()},
-            _meta_source={key: item[idx] for key, item in self.items_meta()},
+            _meta_source={
+                key: item[idx]
+                for key, item in self.items_meta(make_unset=False)
+                if not item.is_tensordict()
+            },
             batch_size=_getitem_batch_size(self.batch_size, idx),
             device=self._device_safe(),
         )


### PR DESCRIPTION
## Description

Fix for #367 
This code snippet should display tensors of size [2, 1] and not [150, 2, 1]:

```python
from torchrl.data import TensorDict
import torch
import string
z = TensorDict({str(k): TensorDict({k: torch.arange(300).reshape(150, 2) for k in string.ascii_lowercase}, batch_size=[150, 2]) for k in [0, 1, 2, 3, 4]}, batch_size=[150])
print(z[0])
```

TODO:
- [ ] Check other items_meta() in the code and make sure they are called on restriced occasions (expensive to create MetaTensor)
- [ ] Write tests for tensordict representation (#380)

cc @ezhang7423