### PR TITLE
[Feature] Add `ProbabilisticTensorDictModule` dist key mapping support 

### DIFF
--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -82,9 +82,10 @@ class TestTDModule:
 
     @pytest.mark.parametrize("safe", [True, False])
     @pytest.mark.parametrize("spec_type", [None, "bounded", "unbounded"])
+    @pytest.mark.parametrize("out_keys", [["loc", "scale"], ["loc_1", "scale_1"]])
     @pytest.mark.parametrize("lazy", [True, False])
     @pytest.mark.parametrize("exp_mode", ["mode", "random", None])
-    def test_stateful_probabilistic(self, safe, spec_type, lazy, exp_mode):
+    def test_stateful_probabilistic(self, safe, spec_type, lazy, exp_mode, out_keys):
         torch.manual_seed(0)
         param_multiplier = 2
         if lazy:
@@ -97,7 +98,7 @@ class TestTDModule:
             module=NormalParamWrapper(net),
             spec=None,
             in_keys=in_keys,
-            out_keys=["loc", "scale"],
+            out_keys=out_keys,
         )
 
         if spec_type is None:
@@ -113,6 +114,12 @@ class TestTDModule:
         )
 
         kwargs = {"distribution_class": TanhNormal}
+        if out_keys == ["loc", "scale"]:
+            dist_param_keys=["loc", "scale"]
+        elif out_keys == ["loc_1", "scale_1"]:
+            dist_param_keys={"loc": "loc_1", "scale": "scale_1"}
+        else:
+            raise NotImplementedError
 
         if safe and spec is None:
             with pytest.raises(
@@ -123,7 +130,7 @@ class TestTDModule:
                 tensordict_module = ProbabilisticTensorDictModule(
                     module=net,
                     spec=spec,
-                    dist_param_keys=["loc", "scale"],
+                    dist_param_keys=dist_param_keys,
                     out_key_sample=["out"],
                     safe=safe,
                     **kwargs
@@ -133,7 +140,7 @@ class TestTDModule:
             tensordict_module = ProbabilisticTensorDictModule(
                 module=net,
                 spec=spec,
-                dist_param_keys=["loc", "scale"],
+                dist_param_keys=dist_param_keys,
                 out_key_sample=["out"],
                 safe=safe,
                 **kwargs

--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -115,9 +115,9 @@ class TestTDModule:
 
         kwargs = {"distribution_class": TanhNormal}
         if out_keys == ["loc", "scale"]:
-            dist_param_keys=["loc", "scale"]
+            dist_param_keys = ["loc", "scale"]
         elif out_keys == ["loc_1", "scale_1"]:
-            dist_param_keys={"loc": "loc_1", "scale": "scale_1"}
+            dist_param_keys = {"loc": "loc_1", "scale": "scale_1"}
         else:
             raise NotImplementedError
 

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -6,7 +6,7 @@
 import re
 from copy import deepcopy
 from textwrap import indent
-from typing import Iterable, Sequence, Union, Type, Optional, Tuple
+from typing import Sequence, Union, Type, Optional, Tuple
 
 from torch import Tensor
 from torch import distributions as d

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -161,7 +161,7 @@ class ProbabilisticTensorDictModule(TensorDictModule):
             dist_param_keys = [dist_param_keys]
         if isinstance(out_key_sample, str):
             out_key_sample = [out_key_sample]
-        if not isinstance(dist_param_keys,dict):
+        if not isinstance(dist_param_keys, dict):
             dist_param_keys = {param_key: param_key for param_key in dist_param_keys}
         for key in dist_param_keys.values():
             if key not in module.out_keys:
@@ -231,11 +231,12 @@ class ProbabilisticTensorDictModule(TensorDictModule):
 
     def build_dist_from_params(self, tensordict_out: TensorDictBase) -> d.Distribution:
         try:
-            selected_td_out =tensordict_out.select(*self.dist_param_keys.values())
-            dist_kwargs = {dist_key: selected_td_out[td_key] for dist_key, td_key in self.dist_param_keys.items()}
-            dist = self.distribution_class(
-                **dist_kwargs
-            )
+            selected_td_out = tensordict_out.select(*self.dist_param_keys.values())
+            dist_kwargs = {
+                dist_key: selected_td_out[td_key]
+                for dist_key, td_key in self.dist_param_keys.items()
+            }
+            dist = self.distribution_class(**dist_kwargs)
         except TypeError as err:
             if "an unexpected keyword argument" in str(err):
                 raise TypeError(

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -6,7 +6,7 @@
 import re
 from copy import deepcopy
 from textwrap import indent
-from typing import Sequence, Union, Type, Optional, Tuple
+from typing import Iterable, Sequence, Union, Type, Optional, Tuple
 
 from torch import Tensor
 from torch import distributions as d
@@ -50,11 +50,12 @@ class ProbabilisticTensorDictModule(TensorDictModule):
         module (nn.Module): a nn.Module used to map the input to the output parameter space. Can be a functional
             module (FunctionalModule or FunctionalModuleWithBuffers), in which case the `forward` method will expect
             the params (and possibly) buffers keyword arguments.
-        dist_param_keys (str or iterable of str): key(s) that will be produced
+        dist_param_keys (str or iterable of str or dict): key(s) that will be produced
             by the inner TDModule and that will be used to build the distribution.
-            Importantly, those keys must match the keywords used by the distribution
+            Importantly, if it's an iterable of str or strthose keys must match the keywords used by the distribution
             class of interest, e.g. `"loc"` and `"scale"` for the Normal distribution
-            and similar.
+            and similar. If dict, the keys are the keys of the distribution and the values are the
+            keys in the tensordict that will get match to the corresponding distribution keyß.
         out_key_sample (str or iterable of str): keys where the sampled values will be
             written. Importantly, if this key is part of the `out_keys` of the inner model,
             the sampling step will be skipped.
@@ -160,7 +161,9 @@ class ProbabilisticTensorDictModule(TensorDictModule):
             dist_param_keys = [dist_param_keys]
         if isinstance(out_key_sample, str):
             out_key_sample = [out_key_sample]
-        for key in dist_param_keys:
+        if not isinstance(dist_param_keys,dict):
+            dist_param_keys = {param_key: param_key for param_key in dist_param_keys}
+        for key in dist_param_keys.values():
             if key not in module.out_keys:
                 raise RuntimeError(
                     f"The key {key} could not be found in the wrapped module `{type(module)}.out_keys`."
@@ -175,7 +178,8 @@ class ProbabilisticTensorDictModule(TensorDictModule):
             module=module, spec=spec, in_keys=in_keys, out_keys=out_keys, safe=safe
         )
         self.dist_param_keys = dist_param_keys
-        _check_all_str(self.dist_param_keys)
+        _check_all_str(self.dist_param_keys.keys())
+        _check_all_str(self.dist_param_keys.values())
 
         self.default_interaction_mode = default_interaction_mode
         if isinstance(distribution_class, str):
@@ -227,8 +231,10 @@ class ProbabilisticTensorDictModule(TensorDictModule):
 
     def build_dist_from_params(self, tensordict_out: TensorDictBase) -> d.Distribution:
         try:
+            selected_td_out =tensordict_out.select(*self.dist_param_keys.values())
+            dist_kwargs = {dist_key: selected_td_out[td_key] for dist_key, td_key in self.dist_param_keys.items()}
             dist = self.distribution_class(
-                **tensordict_out.select(*self.dist_param_keys)
+                **dist_kwargs
             )
         except TypeError as err:
             if "an unexpected keyword argument" in str(err):

--- a/torchrl/modules/tensordict_module/probabilistic.py
+++ b/torchrl/modules/tensordict_module/probabilistic.py
@@ -52,10 +52,10 @@ class ProbabilisticTensorDictModule(TensorDictModule):
             the params (and possibly) buffers keyword arguments.
         dist_param_keys (str or iterable of str or dict): key(s) that will be produced
             by the inner TDModule and that will be used to build the distribution.
-            Importantly, if it's an iterable of str or strthose keys must match the keywords used by the distribution
+            Importantly, if it's an iterable of string or a string, those keys must match the keywords used by the distribution
             class of interest, e.g. `"loc"` and `"scale"` for the Normal distribution
-            and similar. If dict, the keys are the keys of the distribution and the values are the
-            keys in the tensordict that will get match to the corresponding distribution keyß.
+            and similar. If dist_param_keys is a dictionary,, the keys are the keys of the distribution and the values are the
+            keys in the tensordict that will get match to the corresponding distribution keys.
         out_key_sample (str or iterable of str): keys where the sampled values will be
             written. Importantly, if this key is part of the `out_keys` of the inner model,
             the sampling step will be skipped.
@@ -142,7 +142,7 @@ class ProbabilisticTensorDictModule(TensorDictModule):
     def __init__(
         self,
         module: TensorDictModule,
-        dist_param_keys: Union[str, Sequence[str]],
+        dist_param_keys: Union[str, Sequence[str], dict],
         out_key_sample: Union[str, Sequence[str]],
         spec: Optional[TensorSpec] = None,
         safe: bool = False,


### PR DESCRIPTION
## Description

Currently TensorDictModule forces you to have the exact same name of TEnsorDict outputs as the name of the dist you want to build. This PR supports remmaping the TEnsorDictModule output to the right dist name.

## Motivation and Context

This change is required since having the constraint on the names limits the use of ProbabilisticTensorDictModule to a single module. If we want to use 2 modules in a TensorDictSequence, we cannot preserve the dist params at the end of the sequence: One will get overwritten by the other module output.

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)
- [x] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
