### PR TITLE
[BugFix] Fix gym 0.26 compatibility

### DIFF
--- a/.circleci/unittest/linux/scripts/setup_env.sh
+++ b/.circleci/unittest/linux/scripts/setup_env.sh
@@ -83,4 +83,6 @@ if [ $PRIVATE_MUJOCO_GL == 'egl' ] || [ $PRIVATE_MUJOCO_GL == 'osmesa' ] ; then
   yum -y install freeglut
 fi
 
+pip install pip --upgrade
+
 conda env update --file "${this_dir}/environment.yml" --prune

--- a/.circleci/unittest/linux_optdeps/scripts/setup_env.sh
+++ b/.circleci/unittest/linux_optdeps/scripts/setup_env.sh
@@ -51,6 +51,9 @@ conda activate "${env_dir}"
 printf "* Installing dependencies (except PyTorch)\n"
 echo "  - python=${PYTHON_VERSION}" >> "${this_dir}/environment.yml"
 cat "${this_dir}/environment.yml"
+
+pip install pip --upgrade
+
 conda env update --file "${this_dir}/environment.yml" --prune
 
 #yum makecache

--- a/.circleci/unittest/linux_stable/scripts/setup_env.sh
+++ b/.circleci/unittest/linux_stable/scripts/setup_env.sh
@@ -83,4 +83,6 @@ if [ $PRIVATE_MUJOCO_GL == 'egl' ] || [ $PRIVATE_MUJOCO_GL == 'osmesa' ] ; then
   yum -y install freeglut
 fi
 
+pip install pip --upgrade
+
 conda env update --file "${this_dir}/environment.yml" --prune

--- a/test/smoke_test_deps.py
+++ b/test/smoke_test_deps.py
@@ -1,5 +1,7 @@
+import argparse
 import tempfile
 
+import pytest
 from torch.utils.tensorboard import SummaryWriter
 from torchrl.envs.libs.dm_control import _has_dmc, DMControlEnv
 from torchrl.envs.libs.gym import _has_gym, GymEnv
@@ -42,3 +44,8 @@ def test_tb():
             # OS error could be raised randomly
             # depending on the test machine
             test_rounds -= 1
+
+
+if __name__ == "__main__":
+    args, unknown = argparse.ArgumentParser().parse_known_args()
+    pytest.main([__file__, "--capture", "no", "--exitfirst"] + unknown)

--- a/test/test_env.py
+++ b/test/test_env.py
@@ -523,8 +523,8 @@ class TestParallel:
     @pytest.mark.parametrize(
         "env_name",
         [
-            "Pendulum-v1",
             "ALE/Pong-v5",
+            "Pendulum-v1",
         ],
     )
     @pytest.mark.parametrize("frame_skip", [4, 1])

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -189,7 +189,7 @@ def test_dmcontrol(env_name, task, frame_skip, from_pixels, pixels_only):
     assert_allclose_td(rollout0, rollout2)
 
 
-@pytest.mark.skipif(IS_OSX, reason="rendeing unstable on osx, skipping")
+# @pytest.mark.skipif(IS_OSX, reason="rendeing unstable on osx, skipping")
 @pytest.mark.skipif(not (_has_dmc and _has_gym), reason="gym or dm_control not present")
 @pytest.mark.parametrize(
     "env_lib,env_args,env_kwargs",

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -96,10 +96,7 @@ def test_gym(env_name, frame_skip, from_pixels, pixels_only):
             base_env = gym.make(env_name, render_mode="rgb_array")
 
     if from_pixels and not _is_from_pixels(base_env):
-        if gym_version < version.parse("0.26.0"):
-            base_env = PixelObservationWrapper(base_env, pixels_only=pixels_only)
-        else:
-            base_env = PixelObservationWrapper(base_env, pixels_only=pixels_only)
+        base_env = PixelObservationWrapper(base_env, pixels_only=pixels_only)
     assert type(base_env) is env_type
     env1 = GymWrapper(base_env, frame_skip=frame_skip)
     torch.manual_seed(0)

--- a/test/test_libs.py
+++ b/test/test_libs.py
@@ -34,8 +34,8 @@ IS_OSX = platform == "darwin"
 @pytest.mark.parametrize(
     "env_name",
     [
-        "ALE/Pong-v5",
         "Pendulum-v1",
+        "ALE/Pong-v5",
     ],
 )
 @pytest.mark.parametrize("frame_skip", [1, 3])

--- a/torchrl/data/tensor_specs.py
+++ b/torchrl/data/tensor_specs.py
@@ -236,6 +236,15 @@ class TensorSpec:
 
         """
         if not isinstance(val, torch.Tensor):
+            if isinstance(val, list):
+                if len(val) == 1:
+                    # gym used to return lists of images since 0.26.0
+                    # We convert these lists in np.array or take the first element
+                    # if there is just one.
+                    # See https://github.com/facebookresearch/rl/pull/403/commits/73d77d033152c61d96126ccd10a2817fecd285a1
+                    val = val[0]
+                else:
+                    val = np.array(val)
             if _CHECK_IMAGES and val.dtype is np.dtype("uint8"):
                 # images can become noisy during training. if the CHECK_IMAGES
                 # env variable is True, we check that no more than half of the

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -772,9 +772,7 @@ def make_tensordict(
     with torch.no_grad():
         tensordict = env.reset()
         if policy is not None:
-            tensordict = tensordict.unsqueeze(0)
             tensordict = policy(tensordict)
-            tensordict = tensordict.squeeze(0)
         else:
             tensordict.set("action", env.action_spec.rand(), inplace=False)
         tensordict = env.step(tensordict)

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -89,6 +89,18 @@ class GymLikeEnv(_EnvWrapper):
             obs, _reward, done, *info = self._output_transform(
                 self._env.step(action_np)
             )
+            if len(info) == 2:
+                # gym 0.26
+                truncation, info = info
+            elif len(info) == 1:
+                info = info[0]
+            else:
+                raise ValueError(
+                    "the environment output is expected to be either"
+                    "obs, reward, done, truncation, info (gym >= 0.26) or "
+                    f"obs, reward, done, info. Got info with types = ({[type(x) for x in info]})"
+                )
+
             if _reward is None:
                 _reward = 0.0
             reward += _reward
@@ -112,7 +124,7 @@ class GymLikeEnv(_EnvWrapper):
         tensordict_out.set("reward", reward)
         tensordict_out.set("done", done)
         if self.info_dict_reader is not None:
-            self.info_dict_reader(*info, tensordict_out)
+            self.info_dict_reader(info, tensordict_out)
 
         return tensordict_out
 

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -94,6 +94,8 @@ class GymLikeEnv(_EnvWrapper):
                 truncation, info = info
             elif len(info) == 1:
                 info = info[0]
+            elif len(info) == 0:
+                info = None
             else:
                 raise ValueError(
                     "the environment output is expected to be either"
@@ -123,7 +125,7 @@ class GymLikeEnv(_EnvWrapper):
         )
         tensordict_out.set("reward", reward)
         tensordict_out.set("done", done)
-        if self.info_dict_reader is not None:
+        if self.info_dict_reader is not None and info is not None:
             self.info_dict_reader(info, tensordict_out)
 
         return tensordict_out
@@ -132,7 +134,7 @@ class GymLikeEnv(_EnvWrapper):
         self, tensordict: Optional[TensorDictBase] = None, **kwargs
     ) -> TensorDictBase:
         reset_data = self._env.reset(**kwargs)
-        if isinstance(reset_data, np.ndarray):
+        if not isinstance(reset_data, tuple):
             reset_data = (reset_data,)
         obs, *_ = self._output_transform(reset_data)
         tensordict_out = TensorDict(

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -119,7 +119,8 @@ class GymLikeEnv(_EnvWrapper):
     def _reset(
         self, tensordict: Optional[TensorDictBase] = None, **kwargs
     ) -> TensorDictBase:
-        obs, *_ = self._output_transform((self._env.reset(**kwargs),))
+        reset_data = self._env.reset(**kwargs)
+        obs, *_ = self._output_transform(reset_data)
         tensordict_out = TensorDict(
             source=self._read_obs(obs),
             batch_size=self.batch_size,

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -151,6 +151,9 @@ class GymLikeEnv(_EnvWrapper):
     ) -> Dict[str, Any]:
         if isinstance(observations, dict):
             observations = {"next_" + key: value for key, value in observations.items()}
+        if isinstance(observations, list) and len(observations) == 1:
+            # Until gym 0.25.2 we had rendered frames returned in lists of length 1
+            observations = observations[0]
         if not isinstance(observations, (TensorDict, dict)):
             key = list(self.observation_spec.keys())[0]
             observations = {key: observations}

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -120,6 +120,8 @@ class GymLikeEnv(_EnvWrapper):
         self, tensordict: Optional[TensorDictBase] = None, **kwargs
     ) -> TensorDictBase:
         reset_data = self._env.reset(**kwargs)
+        if isinstance(reset_data, np.ndarray):
+            reset_data = (reset_data,)
         obs, *_ = self._output_transform(reset_data)
         tensordict_out = TensorDict(
             source=self._read_obs(obs),

--- a/torchrl/envs/gym_like.py
+++ b/torchrl/envs/gym_like.py
@@ -89,6 +89,9 @@ class GymLikeEnv(_EnvWrapper):
             obs, _reward, done, *info = self._output_transform(
                 self._env.step(action_np)
             )
+            if isinstance(obs, list) and len(obs) == 1:
+                # Until gym 0.25.2 we had rendered frames returned in lists of length 1
+                obs = obs[0]
             if len(info) == 2:
                 # gym 0.26
                 truncation, info = info
@@ -151,9 +154,6 @@ class GymLikeEnv(_EnvWrapper):
     ) -> Dict[str, Any]:
         if isinstance(observations, dict):
             observations = {"next_" + key: value for key, value in observations.items()}
-        if isinstance(observations, list) and len(observations) == 1:
-            # Until gym 0.25.2 we had rendered frames returned in lists of length 1
-            observations = observations[0]
         if not isinstance(observations, (TensorDict, dict)):
             key = list(self.observation_spec.keys())[0]
             observations = {key: observations}

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -48,6 +48,8 @@ if _has_gym:
             GymPixelObservationWrapper as PixelObservationWrapper,
         )
     gym_version = version.parse(gym.__version__)
+    if gym_version >= version.parse("0.26.0"):
+        from gym.wrappers.compatibility import EnvCompatibility
 try:
     import retro
 
@@ -171,7 +173,8 @@ class GymWrapper(GymLikeEnv):
                     "should be created with `gym.make(env_name, render_mode=mode)` where possible,"
                     'where mode is either "rgb_array" or any other supported mode.'
                 )
-                # resetting as 0.26 comes with a very nice OrderEnforcing wrapper
+                # resetting as 0.26 comes with a very 'nice' OrderEnforcing wrapper
+                env = EnvCompatibility(env)
                 env.reset()
                 env = LegacyPixelObservationWrapper(env, pixels_only=pixels_only)
             else:

--- a/torchrl/envs/libs/gym.py
+++ b/torchrl/envs/libs/gym.py
@@ -34,6 +34,7 @@ except ImportError:
 if _has_gym:
     try:
         from gym.wrappers.pixel_observation import PixelObservationWrapper
+
         from torchrl.envs.libs.utils import (
             GymPixelObservationWrapper as LegacyPixelObservationWrapper,
         )
@@ -168,7 +169,7 @@ class GymWrapper(GymLikeEnv):
                 warnings.warn(
                     "Environments provided to GymWrapper that need to be wrapped in PixelObservationWrapper "
                     "should be created with `gym.make(env_name, render_mode=mode)` where possible,"
-                    "where mode is either \"rgb_array\" or any other supported mode."
+                    'where mode is either "rgb_array" or any other supported mode.'
                 )
                 # resetting as 0.26 comes with a very nice OrderEnforcing wrapper
                 env.reset()
@@ -249,10 +250,13 @@ class GymWrapper(GymLikeEnv):
     def info_dict_reader(self, value: callable):
         self._info_dict_reader = value
 
+
 ACCEPTED_TYPE_ERRORS = {
     "render_mode": "__init__() got an unexpected keyword argument 'render_mode'",
     "frame_skip": "unexpected keyword argument 'frameskip'",
 }
+
+
 class GymEnv(GymWrapper):
     """
     OpenAI Gym environment wrapper.
@@ -305,8 +309,12 @@ class GymEnv(GymWrapper):
                 made_env = True
             except TypeError as err:
                 if ACCEPTED_TYPE_ERRORS["frame_skip"] in str(err):
+                    print(
+                        "Discarding frameskip arg. This will be taken care of by TorchRL env wrapper."
+                    )
                     self.wrapper_frame_skip = kwargs.pop("frameskip")
                 elif ACCEPTED_TYPE_ERRORS["render_mode"] in str(err):
+                    print("Discarding render_mode from the env constructor.")
                     kwargs.pop("render_mode")
                 else:
                     raise err


### PR DESCRIPTION
## Description

The return types of gym 0.26 have changed and require an update of our env wrapping.

## For book-keeping

- We have to convert lists of size 1 in arrays otherwise some pixels end up with shape [1, H, W, 3] when the spec indicates they should be [H, W, 3], see [here](https://github.com/facebookresearch/rl/blob/d8742dfcd894f241bcf912b65f06d3c458cf6cd6/torchrl/data/tensor_specs.py#L239-L247) for context.

- Since 0.26.0 also returns a truncation output, we have to account for that. We do it the hacky way for now (see [here](https://github.com/facebookresearch/rl/blob/d8742dfcd894f241bcf912b65f06d3c458cf6cd6/torchrl/envs/gym_like.py#L95-L107)) and leave the option of registering the trunctation for later.
- We also use the [`LegacyPixelEnvironmentWrapper`](https://github.com/facebookresearch/rl/blob/fc04fca216e40ffe21ec7fd90e85a1f9ec2a0ed2/torchrl/envs/libs/gym.py#L168-L178) when `render_mode` is not available
- We change the way we create envs in gym, by trying a set of pre-defined kwargs and discarding them / patching things up if the `__init__` fails with these. See [here](https://github.com/facebookresearch/rl/blob/fc04fca216e40ffe21ec7fd90e85a1f9ec2a0ed2/torchrl/envs/libs/gym.py#L299-L320) for context

TODO in the future:
- Clean up the env building API. It should work:
   - across various gym versions (0.13.0, 0.25.2, 0.26.0)
   - across envs from gym (HalfCheetah, Pendulum, Atari)
   - across envs from other libs (perhaps using the gym-robotics lib with the `EnvCompatibility` wrapper?)