### PR TITLE
[Naming] Recurse kwarg to match pytorch

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -1073,9 +1073,9 @@ class TestTensorDicts:
             "permute_td",
         ):
             with pytest.raises(AssertionError):
-                assert td.clone(recursive=False).get("a") is td.get("a")
+                assert td.clone(recurse=False).get("a") is td.get("a")
         else:
-            assert td.clone(recursive=False).get("a") is td.get("a")
+            assert td.clone(recurse=False).get("a") is td.get("a")
 
     def test_rename_key(self, td_name, device) -> None:
         torch.manual_seed(1)

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -620,7 +620,7 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
     def _get_priority(self, tensordict: TensorDictBase) -> torch.Tensor:
         if self.priority_key in tensordict.keys():
             if tensordict.batch_dims:
-                tensordict = tensordict.clone(recursive=False)
+                tensordict = tensordict.clone(recurse=False)
                 tensordict.batch_size = []
             try:
                 priority = tensordict.get(self.priority_key).item()
@@ -653,7 +653,7 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
                 # we want the tensordict to have one dimension only. The batch size
                 # of the sampled tensordicts can be changed thereafter
                 if not isinstance(tensordicts, LazyStackedTensorDict):
-                    tensordicts = tensordicts.clone(recursive=False)
+                    tensordicts = tensordicts.clone(recurse=False)
                 else:
                     tensordicts = tensordicts.contiguous()
                 tensordicts.batch_size = tensordicts.batch_size[:1]

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -391,7 +391,7 @@ class TransformedEnv(EnvBase):
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         # selected_keys = [key for key in tensordict.keys() if "action" in key]
         # tensordict_in = tensordict.select(*selected_keys).clone()
-        tensordict_in = self.transform.inv(tensordict.clone(recursive=False))
+        tensordict_in = self.transform.inv(tensordict.clone(recurse=False))
         tensordict_out = self.base_env.step(tensordict_in)
         # tensordict should already have been processed by the transforms
         # for logging purposes

--- a/torchrl/modules/functional_modules.py
+++ b/torchrl/modules/functional_modules.py
@@ -205,7 +205,7 @@ def extract_buffers(model):
 
 def _swap_state(model, tensordict, return_old_tensordict=False):
     #     if return_old_tensordict:
-    #         old_tensordict = tensordict.clone(recursive=False)
+    #         old_tensordict = tensordict.clone(recurse=False)
     #         old_tensordict.batch_size = []
 
     if return_old_tensordict:


### PR DESCRIPTION
## Description

Replaces uses of `recursive` kwargs with `recurse` 

## Motivation and Context

PyTorch uses the kwarg `recurse` as a flag for recursion in operations. This library uses the kwarg `recursive` for the same purpose.

This PR brings rl into alignment with PyTorch.

close #406

- [x] ~~I have~~ @vmoens has raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
