### PR TITLE
[BugFix] Temporarily fix gym to 0.25.1 to fix CI

### DIFF
--- a/.circleci/unittest/linux/scripts/environment.yml
+++ b/.circleci/unittest/linux/scripts/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - hypothesis
     - future
     - cloudpickle
-    - gym
+    - gym==0.25.1
     - pygame
     - gym[accept-rom-license]
     - gym[atari]

--- a/.circleci/unittest/linux_stable/scripts/environment.yml
+++ b/.circleci/unittest/linux_stable/scripts/environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - hypothesis
     - future
     - cloudpickle
-    - gym
+    - gym==0.25.1
     - pygame
     - gym[accept-rom-license]
     - gym[atari]


### PR DESCRIPTION
## Description

Our CI is broken because of the recent gym upgrade to 0.26.0.
We temporarily fix the gym version to 0.25.1 until we figure out how to account for BC breaking changes.