### PR TITLE
[Feature] TensorDict without device

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -139,7 +139,8 @@ class TestDQN:
                 "action": action,
                 "action_value": action_value,
             },
-        ).to(device)
+            device=device,
+        )
         return td
 
     def _create_seq_mock_data_dqn(
@@ -355,6 +356,7 @@ class TestDDPG:
                 "reward": reward,
                 "action": action,
             },
+            device=device,
         )
         return td
 
@@ -384,6 +386,7 @@ class TestDDPG:
                 "reward": reward * mask.to(obs.dtype),
                 "action": action * mask.to(obs.dtype),
             },
+            device=device,
         )
         return td
 
@@ -573,6 +576,7 @@ class TestSAC:
                 "reward": reward,
                 "action": action,
             },
+            device=device,
         )
         return td
 
@@ -602,6 +606,7 @@ class TestSAC:
                 "reward": reward * mask.to(obs.dtype),
                 "action": action * mask.to(obs.dtype),
             },
+            device=device,
         )
         return td
 
@@ -917,6 +922,7 @@ class TestREDQ:
                 "reward": reward,
                 "action": action,
             },
+            device=device,
         )
         return td
 
@@ -946,6 +952,7 @@ class TestREDQ:
                 "reward": reward * mask.to(obs.dtype),
                 "action": action * mask.to(obs.dtype),
             },
+            device=device,
         )
         return td
 
@@ -1302,6 +1309,7 @@ class TestPPO:
                 "action": action,
                 "sample_log_prob": torch.randn_like(action[..., :1]) / 10,
             },
+            device=device,
         )
         return td
 
@@ -1338,6 +1346,7 @@ class TestPPO:
                 "loc": params_mean * mask.to(obs.dtype),
                 "scale": params_scale * mask.to(obs.dtype),
             },
+            device=device,
         )
         return td
 

--- a/test/test_exploration.py
+++ b/test/test_exploration.py
@@ -32,7 +32,7 @@ from torchrl.modules.tensordict_module.exploration import (
 @pytest.mark.parametrize("device", get_available_devices())
 def test_ou(device, seed=0):
     torch.manual_seed(seed)
-    td = TensorDict({"action": torch.randn(3, device=device) / 10}, batch_size=[])
+    td = TensorDict({"action": torch.randn(3) / 10}, batch_size=[], device=device)
     ou = _OrnsteinUhlenbeckProcess(10.0, mu=2.0, x0=-4, sigma=0.1, sigma_min=0.01)
 
     tds = []
@@ -232,9 +232,8 @@ def test_gsde(
 
     td = TensorDict(
         {"observation": torch.randn(batch, state_dim, device=device)},
-        [
-            batch,
-        ],
+        [batch],
+        device=device,
     )
     if gSDE:
         gSDENoise().reset(td)

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -26,8 +26,8 @@ from torchrl.data.tensordict.utils import _getitem_batch_size, convert_ellipsis_
 @pytest.mark.parametrize("device", get_available_devices())
 def test_tensordict_set(device):
     torch.manual_seed(1)
-    td = TensorDict({}, batch_size=(4, 5))
-    td.set("key1", torch.randn(4, 5, device=device))
+    td = TensorDict({}, batch_size=(4, 5), device=device)
+    td.set("key1", torch.randn(4, 5))
     assert td.device == torch.device(device)
     # by default inplace:
     with pytest.raises(RuntimeError):
@@ -64,6 +64,43 @@ def test_tensordict_set(device):
         inplace=False,
     )
     assert td._dict_meta["key1"].shape == td._tensordict["key1"].shape
+
+
+@pytest.mark.parametrize("device", get_available_devices())
+def test_tensordict_device(device):
+    tensordict = TensorDict({"a": torch.randn(3, 4)}, [])
+    with pytest.raises(RuntimeError):
+        tensordict.device
+
+    tensordict = TensorDict({"a": torch.randn(3, 4, device=device)}, [])
+    assert tensordict["a"].device == device
+    with pytest.raises(RuntimeError):
+        tensordict.device
+
+    tensordict = TensorDict(
+        {
+            "a": torch.randn(3, 4, device=device),
+            "b": torch.randn(3, 4),
+            "c": torch.randn(3, 4, device="cpu"),
+        },
+        [],
+        device=device,
+    )
+    assert tensordict.device == device
+    assert tensordict["a"].device == device
+    assert tensordict["b"].device == device
+    assert tensordict["c"].device == device
+
+    tensordict = TensorDict({}, [], device=device)
+    tensordict["a"] = torch.randn(3, 4)
+    tensordict["b"] = torch.randn(3, 4, device="cpu")
+    assert tensordict["a"].device == device
+    assert tensordict["b"].device == device
+
+    tensordict = TensorDict({"a": torch.randn(3, 4)}, [])
+    tensordict = tensordict.to(device)
+    assert tensordict.device == device
+    assert tensordict["a"].device == device
 
 
 def test_pad():
@@ -558,75 +595,82 @@ class TestTensorDicts:
     def td(self, device):
         return TensorDict(
             source={
-                "a": torch.randn(4, 3, 2, 1, 5, device=device),
-                "b": torch.randn(4, 3, 2, 1, 10, device=device),
-                "c": torch.randint(10, (4, 3, 2, 1, 3), device=device),
+                "a": torch.randn(4, 3, 2, 1, 5),
+                "b": torch.randn(4, 3, 2, 1, 10),
+                "c": torch.randint(10, (4, 3, 2, 1, 3)),
             },
             batch_size=[4, 3, 2, 1],
+            device=device,
         )
 
     def nested_td(self, device):
         return TensorDict(
             source={
-                "a": torch.randn(4, 3, 2, 1, 5, device=device),
-                "b": torch.randn(4, 3, 2, 1, 10, device=device),
-                "c": torch.randint(10, (4, 3, 2, 1, 3), device=device),
+                "a": torch.randn(4, 3, 2, 1, 5),
+                "b": torch.randn(4, 3, 2, 1, 10),
+                "c": torch.randint(10, (4, 3, 2, 1, 3)),
                 "my_nested_td": TensorDict(
-                    {"inner": torch.randn(4, 3, 2, 1, 2, device=device)}, [4, 3, 2, 1]
+                    {"inner": torch.randn(4, 3, 2, 1, 2)}, [4, 3, 2, 1]
                 ),
             },
             batch_size=[4, 3, 2, 1],
+            device=device,
         )
 
     def stacked_td(self, device):
         td1 = TensorDict(
             source={
-                "a": torch.randn(4, 3, 1, 5, device=device),
-                "b": torch.randn(4, 3, 1, 10, device=device),
-                "c": torch.randint(10, (4, 3, 1, 3), device=device),
+                "a": torch.randn(4, 3, 1, 5),
+                "b": torch.randn(4, 3, 1, 10),
+                "c": torch.randint(10, (4, 3, 1, 3)),
             },
             batch_size=[4, 3, 1],
+            device=device,
         )
         td2 = TensorDict(
             source={
-                "a": torch.randn(4, 3, 1, 5, device=device),
-                "b": torch.randn(4, 3, 1, 10, device=device),
-                "c": torch.randint(10, (4, 3, 1, 3), device=device),
+                "a": torch.randn(4, 3, 1, 5),
+                "b": torch.randn(4, 3, 1, 10),
+                "c": torch.randint(10, (4, 3, 1, 3)),
             },
             batch_size=[4, 3, 1],
+            device=device,
         )
         return stack_td([td1, td2], 2)
 
     def idx_td(self, device):
         td = TensorDict(
             source={
-                "a": torch.randn(2, 4, 3, 2, 1, 5, device=device),
-                "b": torch.randn(2, 4, 3, 2, 1, 10, device=device),
-                "c": torch.randint(10, (2, 4, 3, 2, 1, 3), device=device),
+                "a": torch.randn(2, 4, 3, 2, 1, 5),
+                "b": torch.randn(2, 4, 3, 2, 1, 10),
+                "c": torch.randint(10, (2, 4, 3, 2, 1, 3)),
             },
             batch_size=[2, 4, 3, 2, 1],
+            device=device,
         )
         return td[1]
 
     def sub_td(self, device):
         td = TensorDict(
             source={
-                "a": torch.randn(2, 4, 3, 2, 1, 5, device=device),
-                "b": torch.randn(2, 4, 3, 2, 1, 10, device=device),
-                "c": torch.randint(10, (2, 4, 3, 2, 1, 3), device=device),
+                "a": torch.randn(2, 4, 3, 2, 1, 5),
+                "b": torch.randn(2, 4, 3, 2, 1, 10),
+                "c": torch.randint(10, (2, 4, 3, 2, 1, 3)),
             },
             batch_size=[2, 4, 3, 2, 1],
+            device=device,
         )
         return td.get_sub_tensordict(1)
 
     def sub_td2(self, device):
         td = TensorDict(
             source={
-                "a": torch.randn(4, 2, 3, 2, 1, 5, device=device),
-                "b": torch.randn(4, 2, 3, 2, 1, 10, device=device),
-                "c": torch.randint(10, (4, 2, 3, 2, 1, 3), device=device),
+                "a": torch.randn(4, 2, 3, 2, 1, 5),
+                "b": torch.randn(4, 2, 3, 2, 1, 10),
+                "c": torch.randint(10, (4, 2, 3, 2, 1, 3)),
             },
             batch_size=[4, 2, 3, 2, 1],
+            device=device,
         )
         return td.get_sub_tensordict((slice(None), 1))
 
@@ -639,11 +683,12 @@ class TestTensorDicts:
     def permute_td(self, device):
         return TensorDict(
             source={
-                "a": torch.randn(3, 1, 4, 2, 5, device=device),
-                "b": torch.randn(3, 1, 4, 2, 10, device=device),
-                "c": torch.randint(10, (3, 1, 4, 2, 3), device=device),
+                "a": torch.randn(3, 1, 4, 2, 5),
+                "b": torch.randn(3, 1, 4, 2, 10),
+                "c": torch.randint(10, (3, 1, 4, 2, 3)),
             },
             batch_size=[3, 1, 4, 2],
+            device=device,
         ).permute(2, 0, 3, 1)
         # return TensorDict(
         #     source={
@@ -669,33 +714,36 @@ class TestTensorDicts:
     def unsqueezed_td(self, device):
         td = TensorDict(
             source={
-                "a": torch.randn(4, 3, 2, 5, device=device),
-                "b": torch.randn(4, 3, 2, 10, device=device),
-                "c": torch.randint(10, (4, 3, 2, 3), device=device),
+                "a": torch.randn(4, 3, 2, 5),
+                "b": torch.randn(4, 3, 2, 10),
+                "c": torch.randint(10, (4, 3, 2, 3)),
             },
             batch_size=[4, 3, 2],
+            device=device,
         )
         return td.unsqueeze(-1)
 
     def squeezed_td(self, device):
         td = TensorDict(
             source={
-                "a": torch.randn(4, 3, 1, 2, 1, 5, device=device),
-                "b": torch.randn(4, 3, 1, 2, 1, 10, device=device),
-                "c": torch.randint(10, (4, 3, 1, 2, 1, 3), device=device),
+                "a": torch.randn(4, 3, 1, 2, 1, 5),
+                "b": torch.randn(4, 3, 1, 2, 1, 10),
+                "c": torch.randint(10, (4, 3, 1, 2, 1, 3)),
             },
             batch_size=[4, 3, 1, 2, 1],
+            device=device,
         )
         return td.squeeze(2)
 
     def td_reset_bs(self, device):
         td = TensorDict(
             source={
-                "a": torch.randn(4, 3, 2, 1, 5, device=device),
-                "b": torch.randn(4, 3, 2, 1, 10, device=device),
-                "c": torch.randint(10, (4, 3, 2, 1, 3), device=device),
+                "a": torch.randn(4, 3, 2, 1, 5),
+                "b": torch.randn(4, 3, 2, 1, 10),
+                "c": torch.randint(10, (4, 3, 2, 1, 3)),
             },
             batch_size=[4, 3, 2],
+            device=device,
         )
         td.batch_size = torch.Size([4, 3, 2, 1])
         return td
@@ -1625,8 +1673,10 @@ def test_create_on_device():
     td = TensorDict({}, [5])
     with pytest.raises(RuntimeError):
         td.device
+
     td.set("a", torch.randn(5, device=device))
-    assert td.device == device
+    with pytest.raises(RuntimeError):
+        td.device
 
     td = TensorDict({}, [5], device="cuda:0")
     td.set("a", torch.randn(5, 1))
@@ -1639,9 +1689,11 @@ def test_create_on_device():
     with pytest.raises(RuntimeError):
         stackedtd.device
     stackedtd.set("a", torch.randn(2, 5, device=device))
+    with pytest.raises(RuntimeError):
+        stackedtd.device
+
+    stackedtd = stackedtd.to(device)
     assert stackedtd.device == device
-    assert td1.device == device
-    assert td2.device == device
 
     td1 = TensorDict({}, [5], device="cuda:0")
     td2 = TensorDict({}, [5], device="cuda:0")
@@ -1657,20 +1709,17 @@ def test_create_on_device():
     with pytest.raises(RuntimeError):
         subtd.device
     subtd.set("a", torch.randn(1, device=device))
+    with pytest.raises(RuntimeError):
+        # setting element of subtensordict doesn't set top-level device
+        subtd.device
+    subtd = subtd.to(device)
     assert subtd.device == device
+    assert subtd["a"].device == device
 
     td = TensorDict({}, [5], device="cuda:0")
     subtd = td[1]
     subtd.set("a", torch.randn(1))
     assert subtd.get("a").device == device
-
-    # TensorDict, indexed, slice
-    td = TensorDict({}, [5])
-    subtd = td[1:3]
-    with pytest.raises(RuntimeError):
-        subtd.device
-    subtd.set("a", torch.randn(2, device=device))
-    assert subtd.device == device
 
     td = TensorDict({}, [5], device="cuda:0")
     subtd = td[1:3]
@@ -1682,7 +1731,7 @@ def test_create_on_device():
     savedtd = td.to(SavedTensorDict)
     with pytest.raises(RuntimeError):
         savedtd.device
-    savedtd.set("a", torch.randn(5, device=device))
+    savedtd = savedtd.to(device)
     assert savedtd.device == device
 
     td = TensorDict({}, [5], device="cuda:0")
@@ -1695,7 +1744,7 @@ def test_create_on_device():
     viewedtd = td.view(2, 3)
     with pytest.raises(RuntimeError):
         viewedtd.device
-    viewedtd.set("a", torch.randn(2, 3, device=device))
+    viewedtd = viewedtd.to(device)
     assert viewedtd.device == device
 
     td = TensorDict({}, [6], device="cuda:0")
@@ -2010,28 +2059,22 @@ def test_filling_empty_tensordict(device, td_type, update):
 
 def test_getitem_nested():
     tensor = torch.randn(4, 5, 6, 7)
-    tensordict = TensorDict({}, [4])
-    sub_tensordict = TensorDict({}, [4, 5])
     sub_sub_tensordict = TensorDict({"c": tensor}, [4, 5, 6])
-    with pytest.raises(RuntimeError, match="The nested tensordict had not device"):
-        tensordict["a"] = sub_tensordict
+    sub_tensordict = TensorDict({}, [4, 5])
+    tensordict = TensorDict({}, [4])
+
     sub_tensordict["b"] = sub_sub_tensordict
     tensordict["a"] = sub_tensordict
 
     # check that content match
-    assert tensordict["a"] is sub_tensordict
-    assert tensordict["a", "b"] is sub_sub_tensordict
-    assert tensordict["a", "b", "c"] is tensor
+    assert (tensordict["a"] == sub_tensordict).all()
+    assert (tensordict["a", "b"] == sub_sub_tensordict).all()
+    assert (tensordict["a", "b", "c"] == tensor).all()
 
     # check that shapes are kept
     assert tensordict.shape == torch.Size([4])
     assert sub_tensordict.shape == torch.Size([4, 5])
     assert sub_sub_tensordict.shape == torch.Size([4, 5, 6])
-
-    # check that device are tracked
-    assert tensordict.device == torch.device("cpu")
-    assert sub_tensordict.device == torch.device("cpu")
-    assert sub_sub_tensordict.device == torch.device("cpu")
 
 
 def test_setitem_nested():

--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -103,6 +103,20 @@ def test_tensordict_device(device):
     assert tensordict["a"].device == device
 
 
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="No cuda device detected")
+@pytest.mark.parametrize("device", get_available_devices()[1:])
+def test_tensordict_error_messages(device):
+    sub1 = TensorDict({"a": torch.randn(2, 3)}, [2])
+    sub2 = TensorDict({"a": torch.randn(2, 3, device=device)}, [2])
+    td1 = TensorDict({"sub": sub1}, [2])
+    td2 = TensorDict({"sub": sub2}, [2])
+
+    with pytest.raises(
+        RuntimeError, match='tensors on different devices at key "sub" / "a"'
+    ):
+        torch.cat([td1, td2], 0)
+
+
 def test_pad():
     dim0_left, dim0_right, dim1_left, dim1_right = [0, 1, 0, 2]
     td = TensorDict(

--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -292,6 +292,7 @@ class TestTransforms:
                 for key in keys
             },
             batch,
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         resize(td)
@@ -331,6 +332,7 @@ class TestTransforms:
                 for key in keys
             },
             batch,
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         cc(td)
@@ -369,6 +371,7 @@ class TestTransforms:
                 for key in keys
             },
             batch,
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         flatten(td)
@@ -410,6 +413,7 @@ class TestTransforms:
                 for key in keys
             },
             batch,
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         unsqueeze(td)
@@ -565,7 +569,9 @@ class TestTransforms:
         gs = GrayScale(keys_in=keys)
         dont_touch = torch.randn(1, nchannels, 16, 16, device=device)
         td = TensorDict(
-            {key: torch.randn(1, nchannels, 16, 16, device=device) for key in keys}, [1]
+            {key: torch.randn(1, nchannels, 16, 16, device=device) for key in keys},
+            [1],
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         gs(td)
@@ -601,6 +607,7 @@ class TestTransforms:
                 for key in keys
             },
             batch,
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         totensorimage(td)
@@ -646,6 +653,7 @@ class TestTransforms:
                 for key in keys
             },
             batch,
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         compose(td)
@@ -698,6 +706,7 @@ class TestTransforms:
                 for key in keys_total
             },
             [1],
+            device=device,
         )
 
         compose.inv(td)
@@ -822,7 +831,7 @@ class TestTransforms:
         key1_tensor = torch.zeros(1, 1, 3, 3, device=device)
         key2_tensor = torch.ones(1, 1, 3, 3, device=device)
         key_tensors = [key1_tensor, key2_tensor]
-        td = TensorDict(dict(zip(keys, key_tensors)), [1])
+        td = TensorDict(dict(zip(keys, key_tensors)), [1], device=device)
         cat_frames = CatFrames(N=N, keys_in=keys)
 
         cat_frames(td)
@@ -842,7 +851,7 @@ class TestTransforms:
         key1_tensor = torch.zeros(1, 1, 3, 3, device=device)
         key2_tensor = torch.ones(1, 1, 3, 3, device=device)
         key_tensors = [key1_tensor, key2_tensor]
-        td = TensorDict(dict(zip(keys, key_tensors)), [1])
+        td = TensorDict(dict(zip(keys, key_tensors)), [1], device=device)
         cat_frames = CatFrames(N=N, keys_in=keys)
 
         cat_frames(td)
@@ -892,6 +901,7 @@ class TestTransforms:
                 for key in keys_total
             },
             [1],
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
         double2float(td)
@@ -952,6 +962,7 @@ class TestTransforms:
                 for value, key in enumerate(keys)
             },
             [1],
+            device=device,
         )
         td.set("dont touch", dont_touch.clone())
 
@@ -1003,11 +1014,9 @@ class TestTransforms:
         misc_copy = misc.clone()
 
         td = TensorDict(
-            {
-                "misc": misc,
-                "reward": reward,
-            },
+            {"misc": misc, "reward": reward},
             batch,
+            device=device,
         )
         br(td)
         assert td["reward"] is reward
@@ -1033,6 +1042,7 @@ class TestTransforms:
                 "reward": torch.randn(*batch, 1, device=device),
             },
             batch,
+            device=device,
         )
         td.set("dont touch", torch.randn(*batch, 1, device=device))
         td_copy = td.clone()
@@ -1053,7 +1063,9 @@ class TestTransforms:
     @pytest.mark.parametrize("device", get_available_devices())
     def test_pin_mem(self, device):
         pin_mem = PinMemoryTransform()
-        td = TensorDict({key: torch.randn(3) for key in ["a", "b", "c"]}, [])
+        td = TensorDict(
+            {key: torch.randn(3) for key in ["a", "b", "c"]}, [], device=device
+        )
         pin_mem(td)
         for item in td.values():
             assert item.is_pinned

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -41,7 +41,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
             "mask",
             torch.ones(
                 rollout_tensordict.shape,
-                device=rollout_tensordict._device_safe(),
+                device=rollout_tensordict.device_safe(),
                 dtype=torch.bool,
             ),
         )
@@ -66,7 +66,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
     }
     td = TensorDict(
         source=out_dict,
-        device=rollout_tensordict._device_safe(),
+        device=rollout_tensordict.device_safe(),
         batch_size=out_dict["mask"].shape[:-1],
     )
     if (out_dict["done"].sum(1) > 1).any():

--- a/torchrl/collectors/utils.py
+++ b/torchrl/collectors/utils.py
@@ -41,7 +41,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
             "mask",
             torch.ones(
                 rollout_tensordict.shape,
-                device=rollout_tensordict.device,
+                device=rollout_tensordict._device_safe(),
                 dtype=torch.bool,
             ),
         )
@@ -66,7 +66,7 @@ def split_trajectories(rollout_tensordict: TensorDictBase) -> TensorDictBase:
     }
     td = TensorDict(
         source=out_dict,
-        device=rollout_tensordict.device,
+        device=rollout_tensordict._device_safe(),
         batch_size=out_dict["mask"].shape[:-1],
     )
     if (out_dict["done"].sum(1) > 1).any():

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -367,8 +367,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         # x = first_field(data)
         # if isinstance(x, torch.Tensor):
         device = (
-            data._device_safe()
-            if hasattr(data, "_device_safe")
+            data.device_safe()
+            if hasattr(data, "device_safe")
             else (data.device if hasattr(data, "device") else torch.device("cpu"))
         )
         weight = to_torch(weight, device, self._pin_memory)
@@ -474,8 +474,8 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         # x = first_field(data)  # avoid calling tree.flatten
         # if isinstance(x, torch.Tensor):
         device = (
-            data._device_safe()
-            if hasattr(data, "_device_safe")
+            data.device_safe()
+            if hasattr(data, "device_safe")
             else (data.device if hasattr(data, "device") else torch.device("cpu"))
         )
         weight = to_torch(weight, device, self._pin_memory)
@@ -669,7 +669,7 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
                 "index",
                 torch.zeros(
                     tensordicts.shape,
-                    device=tensordicts._device_safe(),
+                    device=tensordicts.device_safe(),
                     dtype=torch.int,
                 ),
             )
@@ -683,7 +683,7 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
         idx = super().extend(tensordicts, priorities)
         stacked_td.set(
             "index",
-            torch.tensor(idx, dtype=torch.int, device=stacked_td._device_safe()),
+            torch.tensor(idx, dtype=torch.int, device=stacked_td.device_safe()),
             inplace=True,
         )
         return idx

--- a/torchrl/data/replay_buffers/replay_buffers.py
+++ b/torchrl/data/replay_buffers/replay_buffers.py
@@ -366,7 +366,11 @@ class PrioritizedReplayBuffer(ReplayBuffer):
         weight = np.power(weight / p_min, -self._beta)
         # x = first_field(data)
         # if isinstance(x, torch.Tensor):
-        device = data.device if hasattr(data, "device") else torch.device("cpu")
+        device = (
+            data._device_safe()
+            if hasattr(data, "_device_safe")
+            else (data.device if hasattr(data, "device") else torch.device("cpu"))
+        )
         weight = to_torch(weight, device, self._pin_memory)
         return data, weight
 
@@ -469,7 +473,11 @@ class PrioritizedReplayBuffer(ReplayBuffer):
 
         # x = first_field(data)  # avoid calling tree.flatten
         # if isinstance(x, torch.Tensor):
-        device = data.device if hasattr(data, "device") else torch.device("cpu")
+        device = (
+            data._device_safe()
+            if hasattr(data, "_device_safe")
+            else (data.device if hasattr(data, "device") else torch.device("cpu"))
+        )
         weight = to_torch(weight, device, self._pin_memory)
         return data, weight, index
 
@@ -660,7 +668,9 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
             tensordicts.set(
                 "index",
                 torch.zeros(
-                    tensordicts.shape, device=tensordicts.device, dtype=torch.int
+                    tensordicts.shape,
+                    device=tensordicts._device_safe(),
+                    dtype=torch.int,
                 ),
             )
         else:
@@ -673,7 +683,7 @@ class TensorDictPrioritizedReplayBuffer(PrioritizedReplayBuffer):
         idx = super().extend(tensordicts, priorities)
         stacked_td.set(
             "index",
-            torch.tensor(idx, dtype=torch.int, device=stacked_td.device),
+            torch.tensor(idx, dtype=torch.int, device=stacked_td._device_safe()),
             inplace=True,
         )
         return idx

--- a/torchrl/data/tensordict/metatensor.py
+++ b/torchrl/data/tensordict/metatensor.py
@@ -79,7 +79,17 @@ class MetaTensor:
                 _is_shared = tensor.is_shared()
             if _is_memmap is None:
                 _is_memmap = isinstance(tensor, MemmapTensor)
-            device = tensor.device if not tensor.is_meta else device
+            # FIXME: using isinstance(tensor, TensorDictBase) would likely be
+            # better here, but creates circular import without more refactoring
+            device = (
+                (
+                    tensor._device_safe()
+                    if hasattr(tensor, "_device_safe")
+                    else tensor.device
+                )
+                if not tensor.is_meta
+                else device
+            )
             if _is_tensordict is None:
                 _is_tensordict = not _is_memmap and not isinstance(tensor, torch.Tensor)
             if not _is_tensordict:

--- a/torchrl/data/tensordict/metatensor.py
+++ b/torchrl/data/tensordict/metatensor.py
@@ -83,8 +83,8 @@ class MetaTensor:
             # better here, but creates circular import without more refactoring
             device = (
                 (
-                    tensor._device_safe()
-                    if hasattr(tensor, "_device_safe")
+                    tensor.device_safe()
+                    if hasattr(tensor, "device_safe")
                     else tensor.device
                 )
                 if not tensor.is_meta

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -175,12 +175,13 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     @property
     @abc.abstractmethod
     def device(self) -> torch.device:
-        """Device of a TensorDict. All tensors of a tensordict must live on the
-        same device.
+        """Device of a TensorDict. If the TensorDict has a specified device, all
+        tensors of a tensordict must live on the same device. If the TensorDict device
+        is None, then different values can be located on different devices.
 
         Returns:
             torch.device object indicating the device where the tensors
-            are placed.
+            are placed, or None if TensorDict does not have a device.
 
         """
         raise NotImplementedError
@@ -302,8 +303,6 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
             key (str): name of the value
             list_item (list of torch.Tensor): value to be stacked and stored in the tensordict.
             dim (int): dimension along which the tensors should be stacked.
-            no_check (bool, optional): if True, it is assumed that device and shape
-                match the original tensor and that the keys is in the tensordict.
 
         Returns:
             self
@@ -576,20 +575,6 @@ dtype=torch.float32)},
         if check_device and self._device_safe() is not None:
             device = self.device
             tensor = tensor.to(device)
-        elif self._device_safe() is None:
-            if isinstance(tensor, TensorDictBase):
-                device = tensor._device_safe()
-                if device is not None:
-                    self.device = device
-                else:
-                    raise RuntimeError(
-                        "The nested tensordict had not device. "
-                        "When nesting tensordicts, the nested tensordict must have "
-                        "a defined device (either by specifying it upon creation or "
-                        "by populating it with at tensor)."
-                    )
-            else:
-                self.device = tensor.device
 
         if check_shared:
             raise DeprecationWarning("check_shared is not authorized anymore")
@@ -726,7 +711,7 @@ dtype=torch.float32)},
         )
 
     def __eq__(self, other: object) -> TensorDictBase:
-        """Compares two tensordicts against each other, for evey key. The two
+        """Compares two tensordicts against each other, for every key. The two
         tensordicts must have the same key set.
 
         Returns:
@@ -899,7 +884,7 @@ dtype=torch.float32)},
                 else value.to_tensordict()
                 for key, value in self.items()
             },
-            device=self.device,
+            device=self._device_safe(),
             batch_size=self.batch_size,
         )
 
@@ -1356,7 +1341,7 @@ dtype=torch.float32)},
         fields = _td_fields(self)
         field_str = indent(f"fields={{{fields}}}", 4 * " ")
         batch_size_str = indent(f"batch_size={self.batch_size}", 4 * " ")
-        device_str = indent(f"device={self.device}", 4 * " ")
+        device_str = indent(f"device={self._device_safe()}", 4 * " ")
         is_shared_str = indent(f"is_shared={self.is_shared()}", 4 * " ")
         string = ",\n".join([field_str, batch_size_str, device_str, is_shared_str])
         return f"{type(self).__name__}(\n{string})"
@@ -1478,13 +1463,15 @@ dtype=torch.float32)},
                     if separator not in key[1:-1]
                 },
                 batch_size=self.batch_size,
-                device=self.device,
+                device=self._device_safe(),
             )
         else:
             out = self
 
         for key, list_of_keys in to_unflatten.items():
-            tensordict = TensorDict({}, batch_size=self.batch_size, device=self.device)
+            tensordict = TensorDict(
+                {}, batch_size=self.batch_size, device=self._device_safe()
+            )
             for (old_key, new_key) in list_of_keys:
                 value = self[old_key]
                 tensordict[new_key] = value
@@ -1521,12 +1508,12 @@ dtype=torch.float32)},
 
         """
         if isinstance(idx, list):
-            idx = torch.tensor(idx, device=self.device)
+            idx = torch.tensor(idx, device=self._device_safe())
         if isinstance(idx, tuple) and any(
             isinstance(sub_index, list) for sub_index in idx
         ):
             idx = tuple(
-                torch.tensor(sub_index, device=self.device)
+                torch.tensor(sub_index, device=self._device_safe())
                 if isinstance(sub_index, list)
                 else sub_index
                 for sub_index in idx
@@ -1554,7 +1541,7 @@ dtype=torch.float32)},
             )
 
         if isinstance(idx, np.ndarray):
-            idx = torch.tensor(idx, device=self.device)
+            idx = torch.tensor(idx, device=self._device_safe())
         if idx is Ellipsis or (isinstance(idx, tuple) and Ellipsis in idx):
             idx = convert_ellipsis_to_idx(idx, self.batch_size)
 
@@ -1574,12 +1561,12 @@ dtype=torch.float32)},
         if index is Ellipsis or (isinstance(index, tuple) and Ellipsis in index):
             index = convert_ellipsis_to_idx(index, self.batch_size)
         if isinstance(index, list):
-            index = torch.tensor(index, device=self.device)
+            index = torch.tensor(index, device=self._device_safe())
         if isinstance(index, tuple) and any(
             isinstance(sub_index, list) for sub_index in index
         ):
             index = tuple(
-                torch.tensor(sub_index, device=self.device)
+                torch.tensor(sub_index, device=self._device_safe())
                 if isinstance(sub_index, list)
                 else sub_index
                 for sub_index in index
@@ -1699,9 +1686,11 @@ class TensorDict(TensorDictBase):
     TensorDict is a tensor container where all tensors are stored in a
     key-value pair fashion and where each element shares at least the
     following features:
-    - device;
     - memory location (shared, memory-mapped array, ...);
     - batch size (i.e. n^th first dimensions).
+
+    Additionally, if the tensordict has a specified device, then each element
+    must share that device.
 
     TensorDict instances support many regular tensor operations as long as
     they are dtype-independent (as a TensorDict instance can contain tensors
@@ -1751,9 +1740,7 @@ class TensorDict(TensorDictBase):
             source is another TensorDict, the batch_size argument must be
             provided as it won't be inferred from the data.
         device (torch.device or compatible type, optional): a device for the
-            TensorDict. If the source is non-empty and the device is
-            missing, it will be inferred from the input dictionary, assuming
-            that all tensors are on the same device.
+            TensorDict.
 
     Examples:
         >>> import torch
@@ -1806,13 +1793,7 @@ class TensorDict(TensorDictBase):
                 "A TensorDict source is expected to be a TensorDictBase "
                 f"sub-type or a dictionary, found type(source)={type(source)}."
             )
-        if isinstance(
-            batch_size,
-            (
-                Number,
-                Sequence,
-            ),
-        ):
+        if isinstance(batch_size, (Number, Sequence)):
             if not isinstance(batch_size, torch.Size):
                 if isinstance(batch_size, int):
                     batch_size = torch.Size([batch_size])
@@ -1828,17 +1809,14 @@ class TensorDict(TensorDictBase):
                 "instance and it could not be retrieved from source."
             )
 
-        if isinstance(source, TensorDictBase) and device is None:
-            device = source._device_safe()
-        elif device is not None:
+        if device is not None:
             device = torch.device(device)
 
-        map_item_to_device = device is not None
         self._device = device
 
         if source is not None:
             for key, value in source.items():
-                if map_item_to_device:
+                if device is not None:
                     value = value.to(device)
                 _meta_val = (
                     None
@@ -1890,22 +1868,20 @@ class TensorDict(TensorDictBase):
         if device is None:
             raise RuntimeError(
                 "Querying a tensordict device when it has not been set is not "
-                "permitted. Either populate the tensordict with a tensor or set "
-                "the device upon creation using de `device=dest` keyword."
+                "permitted. Set the device upon creation using the "
+                "`device=dest` keyword, or subsequently using "
+                "`tensordict.to(device)."
             )
         return device
 
     @device.setter
     def device(self, value: DEVICE_TYPING) -> None:
-        if self._device is None:
-            self._device = torch.device(value)
-        else:
-            raise RuntimeError(
-                "device cannot be set using tensordict.device = device, "
-                "because device cannot be updated in-place. To update device, use "
-                "tensordict.to(new_device), which will return a new tensordict "
-                "on the new device."
-            )
+        raise RuntimeError(
+            "device cannot be set using tensordict.device = device, "
+            "because device cannot be updated in-place. To update device, use "
+            "tensordict.to(new_device), which will return a new tensordict "
+            "on the new device."
+        )
 
     def _device_safe(self) -> Union[None, torch.device]:
         return self._device
@@ -1953,12 +1929,24 @@ class TensorDict(TensorDictBase):
         return all(memmap_list) and len(memmap_list) > 0
 
     def _check_device(self) -> None:
-        devices = set(value.device for value in self.values_meta())
-        if len(devices) > 1:
-            raise RuntimeError(f"Found more than one device: {devices}")
+        devices = set(
+            # make sure we don't raise an exception if we have nested TensorDicts
+            value._device_safe() if isinstance(value, TensorDictBase) else value.device
+            for value in self.values_meta()
+        )
+        if (
+            self._device_safe() is not None
+            and len(devices) >= 1
+            and devices != {self._device_safe()}
+        ):
+            raise RuntimeError(
+                f"TensorDict.device is {self._device}, but elements have "
+                f"device values {devices}. If TensorDict.device is set then "
+                "all elements must share that device."
+            )
 
     def pin_memory(self) -> TensorDictBase:
-        if self.device == torch.device("cpu"):
+        if self._device_safe() == torch.device("cpu"):
             for key, value in self.items():
                 if isinstance(value, TensorDictBase) or (
                     value.dtype in (torch.half, torch.float, torch.double)
@@ -2166,7 +2154,7 @@ class TensorDict(TensorDictBase):
                 "share_memory_ must be called when the TensorDict is ("
                 "partially) populated. Set a tensor first."
             )
-        if self.device != torch.device("cpu"):
+        if self._device_safe() != torch.device("cpu"):
             # cuda tensors are shared by default
             return self
         for value in self.values():
@@ -2284,6 +2272,36 @@ class TensorDict(TensorDictBase):
         return self._tensordict.keys()
 
 
+class _ErrorInteceptor:
+    """Context manager for catching errors and modifying message. Intended for
+    use with stacking / concatenation operations applied to TensorDicts.
+    """
+
+    DEFAULT_EXC_MSG = "Expected all tensors to be on the same device"
+
+    def __init__(
+        self, key, prefix, exc_msg: str = None, exc_type: Type[Exception] = None
+    ):
+        self.exc_type = exc_type if exc_type is not None else RuntimeError
+        self.exc_msg = exc_msg if exc_msg is not None else self.DEFAULT_EXC_MSG
+        self.prefix = prefix
+        self.key = key
+
+    def _add_key_to_error_msg(self, msg: str) -> str:
+        if msg.startswith(self.prefix):
+            return f'{self.prefix} "{self.key}" /{msg[len(self.prefix):]}'
+        return f'{self.prefix} "{self.key}". {msg}'
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, _):
+        if exc_type is self.exc_type and (
+            self.exc_msg is None or self.exc_msg in str(exc_value)
+        ):
+            exc_value.args = (self._add_key_to_error_msg(str(exc_value)),)
+
+
 def implements_for_td(torch_function: Callable) -> Callable:
     """Register a torch function override for ScalarTensor"""
 
@@ -2381,8 +2399,6 @@ def cat(
 ) -> TensorDictBase:
     if not list_of_tensordicts:
         raise RuntimeError("list_of_tensordicts cannot be empty")
-    if not device:
-        device = list_of_tensordicts[0].device
     if dim < 0:
         raise RuntimeError(
             f"negative dim in torch.dim(list_of_tensordicts, dim=dim) not "
@@ -2401,9 +2417,12 @@ def cat(
     # check that all tensordict match
     keys = _check_keys(list_of_tensordicts, strict=True)
     if out is None:
-        out = dict()
+        out = {}
         for key in keys:
-            out[key] = torch.cat([td.get(key) for td in list_of_tensordicts], dim)
+            with _ErrorInteceptor(
+                key, "Attempted to concatenate tensors on different devices at key"
+            ):
+                out[key] = torch.cat([td.get(key) for td in list_of_tensordicts], dim)
         out = TensorDict(out, device=device, batch_size=batch_size, _run_checks=False)
         return out
     else:
@@ -2415,7 +2434,12 @@ def cat(
             )
 
         for key in keys:
-            out.set_(key, torch.cat([td.get(key) for td in list_of_tensordicts], dim))
+            with _ErrorInteceptor(
+                key, "Attempted to concatenate tensors on different devices at key"
+            ):
+                out.set_(
+                    key, torch.cat([td.get(key) for td in list_of_tensordicts], dim)
+                )
         return out
 
 
@@ -2423,6 +2447,7 @@ def cat(
 def stack(
     list_of_tensordicts: Sequence[TensorDictBase],
     dim: int = 0,
+    device: DEVICE_TYPING = None,
     out: TensorDictBase = None,
     strict=False,
     contiguous=False,
@@ -2445,27 +2470,31 @@ def stack(
 
     if out is None:
         device = list_of_tensordicts[0]._device_safe()
-        out = (
-            TensorDict(
-                {
-                    key: torch.stack(
+        if contiguous:
+            out = {}
+            for key in keys:
+                with _ErrorInteceptor(
+                    key, "Attempted to stack tensors on different devices at key"
+                ):
+                    out[key] = torch.stack(
                         [_tensordict.get(key) for _tensordict in list_of_tensordicts],
                         dim,
                     )
-                    for key in keys
-                },
+            out = TensorDict(
+                out,
                 batch_size=LazyStackedTensorDict._compute_batch_size(
                     batch_size, dim, len(list_of_tensordicts)
                 ),
                 device=device,
                 _run_checks=False,
             )
-            if contiguous
-            else LazyStackedTensorDict(
+
+        else:
+            out = LazyStackedTensorDict(
                 *list_of_tensordicts,
                 stack_dim=dim,
             )
-        )
+
     else:
         batch_size = list(batch_size)
         batch_size.insert(dim, len(list_of_tensordicts))
@@ -2503,14 +2532,21 @@ def stack(
                     dim,
                 )
             else:
-                out.set(
-                    key,
-                    torch.stack(
-                        [_tensordict.get(key) for _tensordict in list_of_tensordicts],
-                        dim,
-                    ),
-                    inplace=True,
-                )
+                with _ErrorInteceptor(
+                    key, "Attempted to stack tensors on different devices at key"
+                ):
+                    out.set(
+                        key,
+                        torch.stack(
+                            [
+                                _tensordict.get(key)
+                                for _tensordict in list_of_tensordicts
+                            ],
+                            dim,
+                        ),
+                        inplace=True,
+                    )
+
     return out
 
 
@@ -2563,7 +2599,7 @@ def pad(tensordict: TensorDictBase, pad_size: Sequence[int], value: float = 0.0)
     for i in range(0, len(reverse_pad), 2):
         reverse_pad[i], reverse_pad[i + 1] = reverse_pad[i + 1], reverse_pad[i]
 
-    out = TensorDict({}, new_batch_size, device=tensordict.device)
+    out = TensorDict({}, new_batch_size, device=tensordict._device_safe())
     for key, tensor in tensordict.items():
         cur_pad = reverse_pad
         if len(pad_size) < len(tensor.shape) * 2:
@@ -2751,7 +2787,7 @@ torch.Size([3, 2])
             tensor_expand = TensorDict(
                 {
                     key: _expand_to_match_shape(
-                        parent.batch_size, _tensor, self.batch_dims, self.device
+                        parent.batch_size, _tensor, self.batch_dims, self._device_safe()
                     )
                     for key, _tensor in tensor.items()
                 },
@@ -2763,9 +2799,9 @@ torch.Size([3, 2])
                 *parent.batch_size,
                 *tensor.shape[self.batch_dims :],
                 dtype=tensor.dtype,
-                device=self.device,
+                device=self._device_safe(),
             )
-            if self.is_shared() and self.device == torch.device("cpu"):
+            if self.is_shared() and self._device_safe() == torch.device("cpu"):
                 tensor_expand.share_memory_()
             elif self.is_memmap():
                 tensor_expand = MemmapTensor(tensor_expand)
@@ -3101,12 +3137,19 @@ class LazyStackedTensorDict(TensorDictBase):
     @property
     def device(self) -> torch.device:
         # devices might have changed so we check that they're all the same
-        device_set = {td.device for td in self.tensordicts}
+        device_set = {td._device_safe() for td in self.tensordicts}
         if len(device_set) != 1:
             raise RuntimeError(
                 f"found multiple devices in {self.__class__.__name__}:" f" {device_set}"
             )
-        return self.tensordicts[0].device
+        device = self.tensordicts[0]._device_safe()
+        if device is None:
+            raise RuntimeError(
+                "Querying a tensordict device when it has not been set is not "
+                "permitted. Set the device upon creation using the "
+                "`device=dest` keyword."
+            )
+        return device
 
     @device.setter
     def device(self, value: DEVICE_TYPING) -> None:
@@ -3369,12 +3412,12 @@ class LazyStackedTensorDict(TensorDictBase):
 
     def __setitem__(self, item: INDEX_TYPING, value: TensorDictBase) -> TensorDictBase:
         if isinstance(item, list):
-            item = torch.tensor(item, device=self.device)
+            item = torch.tensor(item, device=self._device_safe())
         if isinstance(item, tuple) and any(
             isinstance(sub_index, list) for sub_index in item
         ):
             item = tuple(
-                torch.tensor(sub_index, device=self.device)
+                torch.tensor(sub_index, device=self._device_safe())
                 if isinstance(sub_index, list)
                 else sub_index
                 for sub_index in item
@@ -3412,12 +3455,12 @@ class LazyStackedTensorDict(TensorDictBase):
         ) not in [len(item), 0]:
             raise IndexError(_STR_MIXED_INDEX_ERROR)
         if isinstance(item, list):
-            item = torch.tensor(item, device=self.device)
+            item = torch.tensor(item, device=self._device_safe())
         if isinstance(item, tuple) and any(
             isinstance(sub_index, list) for sub_index in item
         ):
             item = tuple(
-                torch.tensor(sub_index, device=self.device)
+                torch.tensor(sub_index, device=self._device_safe())
                 if isinstance(sub_index, list)
                 else sub_index
                 for sub_index in item
@@ -3612,9 +3655,7 @@ class SavedTensorDict(TensorDictBase):
             torch.device(device)
             if device is not None
             else source._device_safe()
-            if (hasattr(source, "_device_safe") and source._device_safe() is not None)
-            else source[list(source.keys())[0]].device
-            if source.keys()
+            if hasattr(source, "_device_safe")
             else None
         )
         self._save(source)
@@ -3662,22 +3703,21 @@ class SavedTensorDict(TensorDictBase):
                 break
         elif device is None:
             raise RuntimeError(
-                "querying device from an empty tensordict is not permitted, "
-                "unless this device has been specified upon creation."
+                "Querying a tensordict device when it has not been set is not "
+                "permitted. Set the device upon creation using the "
+                "`device=dest` keyword, or subsequently using "
+                "`tensordict.to(device)`."
             )
         return device
 
     @device.setter
     def device(self, value: DEVICE_TYPING) -> None:
-        if self._device is None:
-            self._device = torch.device(value)
-        else:
-            raise RuntimeError(
-                "device cannot be set using tensordict.device = device, "
-                "because device cannot be updated in-place. To update device, use "
-                "tensordict.to(new_device), which will return a new tensordict "
-                "on the new device."
-            )
+        raise RuntimeError(
+            "device cannot be set using tensordict.device = device, "
+            "because device cannot be updated in-place. To update device, use "
+            "tensordict.to(new_device), which will return a new tensordict "
+            "on the new device."
+        )
 
     def _device_safe(self) -> Union[None, torch.device]:
         return self._device
@@ -3812,7 +3852,7 @@ class SavedTensorDict(TensorDictBase):
         return self._load().contiguous()
 
     def clone(self, recursive: bool = True) -> TensorDictBase:
-        return SavedTensorDict(self, device=self.device)
+        return SavedTensorDict(self, device=self._device_safe())
 
     def select(self, *keys: str, inplace: bool = False) -> TensorDictBase:
         _source = self.contiguous().select(*keys)
@@ -3880,7 +3920,7 @@ class SavedTensorDict(TensorDictBase):
                 else value.to_tensordict()
                 for key, value in td.items()
             },
-            device=self.device,
+            device=self._device_safe(),
             batch_size=self.batch_size,
         )
 
@@ -3911,12 +3951,12 @@ class SavedTensorDict(TensorDictBase):
 
     def __getitem__(self, idx: INDEX_TYPING) -> TensorDictBase:
         if isinstance(idx, list):
-            idx = torch.tensor(idx, device=self.device)
+            idx = torch.tensor(idx, device=self._device_safe())
         if isinstance(idx, tuple) and any(
             isinstance(sub_index, list) for sub_index in idx
         ):
             idx = tuple(
-                torch.tensor(sub_index, device=self.device)
+                torch.tensor(sub_index, device=self._device_safe())
                 if isinstance(sub_index, list)
                 else sub_index
                 for sub_index in idx

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -551,7 +551,7 @@ dtype=torch.float32)},
         return self
 
     def _convert_to_tensor(self, array: np.ndarray) -> Union[Tensor, MemmapTensor]:
-        return torch.as_tensor(array, device=self.device)
+        return torch.as_tensor(array, device=self._device_safe())
 
     def _process_tensor(
         self,
@@ -2154,7 +2154,7 @@ class TensorDict(TensorDictBase):
                 "share_memory_ must be called when the TensorDict is ("
                 "partially) populated. Set a tensor first."
             )
-        if self._device_safe() != torch.device("cpu"):
+        if self._device_safe() is not None and self.device != torch.device("cpu"):
             # cuda tensors are shared by default
             return self
         for value in self.values():
@@ -2969,10 +2969,7 @@ torch.Size([3, 2])
     def clone(self, recursive: bool = True) -> SubTensorDict:
         if not recursive:
             return copy(self)
-        return SubTensorDict(
-            source=self._source,
-            idx=self.idx,
-        )
+        return SubTensorDict(source=self._source, idx=self.idx)
 
     def is_contiguous(self) -> bool:
         return all([value.is_contiguous() for _, value in self.items()])

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -195,6 +195,9 @@ class TensorDictBase(Mapping, metaclass=abc.ABCMeta):
     def _device_safe(self) -> Union[None, torch.device]:
         raise NotImplementedError
 
+    def clear_device(self) -> None:
+        self._device = None
+
     def is_shared(self, no_check: bool = True) -> bool:
         """Checks if tensordict is in shared memory.
 

--- a/torchrl/modules/functional_modules.py
+++ b/torchrl/modules/functional_modules.py
@@ -149,7 +149,7 @@ class FunctionalModuleWithBuffers(nn.Module):
         buffers = extract_buffers(model_copy)
         if buffers is None:
             buffers = TensorDict(
-                {}, param_tensordict.batch_size, device=param_tensordict.device
+                {}, param_tensordict.batch_size, device=param_tensordict._device_safe()
             )
         if disable_autograd_tracking:
             param_tensordict.apply(lambda x: x.requires_grad_(False), inplace=True)

--- a/torchrl/modules/functional_modules.py
+++ b/torchrl/modules/functional_modules.py
@@ -149,7 +149,7 @@ class FunctionalModuleWithBuffers(nn.Module):
         buffers = extract_buffers(model_copy)
         if buffers is None:
             buffers = TensorDict(
-                {}, param_tensordict.batch_size, device=param_tensordict._device_safe()
+                {}, param_tensordict.batch_size, device=param_tensordict.device_safe()
             )
         if disable_autograd_tracking:
             param_tensordict.apply(lambda x: x.requires_grad_(False), inplace=True)
@@ -209,7 +209,7 @@ def _swap_state(model, tensordict, return_old_tensordict=False):
     #         old_tensordict.batch_size = []
 
     if return_old_tensordict:
-        old_tensordict = TensorDict({}, [], device=tensordict._device_safe())
+        old_tensordict = TensorDict({}, [], device=tensordict.device_safe())
 
     for key, value in list(tensordict.items()):
         if isinstance(value, TensorDictBase):

--- a/torchrl/objectives/costs/ddpg.py
+++ b/torchrl/objectives/costs/ddpg.py
@@ -79,9 +79,9 @@ class DDPGLoss(LossModule):
             a tuple of 2 tensors containing the DDPG loss.
 
         """
-        if not input_tensordict._device_safe() == self.device:
+        if not input_tensordict.device_safe() == self.device:
             raise RuntimeError(
-                f"Got device={input_tensordict._device_safe()} but "
+                f"Got device={input_tensordict.device_safe()} but "
                 f"actor_network.device={self.device} (self.device={self.device})"
             )
 
@@ -90,7 +90,7 @@ class DDPGLoss(LossModule):
         )
         td_error = td_error.detach()
         td_error = td_error.unsqueeze(input_tensordict.ndimension())
-        if input_tensordict._device_safe() is not None:
+        if input_tensordict.device_safe() is not None:
             td_error = td_error.to(input_tensordict.device)
         input_tensordict.set(
             "td_error",

--- a/torchrl/objectives/costs/ddpg.py
+++ b/torchrl/objectives/costs/ddpg.py
@@ -79,10 +79,10 @@ class DDPGLoss(LossModule):
             a tuple of 2 tensors containing the DDPG loss.
 
         """
-        if not input_tensordict.device == self.device:
+        if not input_tensordict._device_safe() == self.device:
             raise RuntimeError(
-                f"Got device={input_tensordict.device} but actor_network.device={self.device} "
-                f"(self.device={self.device})"
+                f"Got device={input_tensordict._device_safe()} but "
+                f"actor_network.device={self.device} (self.device={self.device})"
             )
 
         loss_value, td_error, pred_val, target_value = self._loss_value(
@@ -90,7 +90,8 @@ class DDPGLoss(LossModule):
         )
         td_error = td_error.detach()
         td_error = td_error.unsqueeze(input_tensordict.ndimension())
-        td_error = td_error.to(input_tensordict.device)
+        if input_tensordict._device_safe() is not None:
+            td_error = td_error.to(input_tensordict.device)
         input_tensordict.set(
             "td_error",
             td_error,

--- a/torchrl/objectives/costs/dqn.py
+++ b/torchrl/objectives/costs/dqn.py
@@ -114,7 +114,7 @@ class DQNLoss(LossModule):
             )
         priority_tensor = (pred_val_index - target_value).pow(2)
         priority_tensor = priority_tensor.detach().unsqueeze(-1)
-        if input_tensordict._device_safe() is not None:
+        if input_tensordict.device_safe() is not None:
             priority_tensor = priority_tensor.to(input_tensordict.device)
 
         input_tensordict.set(

--- a/torchrl/objectives/costs/dqn.py
+++ b/torchrl/objectives/costs/dqn.py
@@ -114,7 +114,8 @@ class DQNLoss(LossModule):
             )
         priority_tensor = (pred_val_index - target_value).pow(2)
         priority_tensor = priority_tensor.detach().unsqueeze(-1)
-        priority_tensor = priority_tensor.to(input_tensordict.device)
+        if input_tensordict._device_safe() is not None:
+            priority_tensor = priority_tensor.to(input_tensordict.device)
 
         input_tensordict.set(
             self.priority_key,

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -684,8 +684,17 @@ class RewardNormalizer:
     def normalize_reward(self, tensordict: TensorDictBase) -> TensorDictBase:
         tensordict = tensordict.to_tensordict()  # make sure it is not a SubTensorDict
         reward = tensordict.get("reward")
-        reward = reward - self._reward_stats["mean"].to(tensordict.device)
-        reward = reward / self._reward_stats["std"].to(tensordict.device)
+
+        reward_device = (
+            reward._device_safe() if hasattr(reward, "_device_safe") else reward.device
+        )
+        if reward_device is not None:
+            reward = reward - self._reward_stats["mean"].to(reward_device)
+            reward = reward / self._reward_stats["std"].to(reward_device)
+        else:
+            reward = reward - self._reward_stats["mean"]
+            reward = reward / self._reward_stats["std"]
+
         tensordict.set("reward", reward * self.scale)
         self._normalize_has_been_called = True
         return tensordict
@@ -777,7 +786,9 @@ class BatchSubSampler:
             )
         else:
             traj_len = (
-                torch.ones(batch.shape[0], device=batch.device, dtype=torch.bool)
+                torch.ones(
+                    batch.shape[0], device=batch._device_safe(), dtype=torch.bool
+                )
                 * batch.shape[1]
             )
         len_mask = traj_len >= sub_traj_len
@@ -792,7 +803,7 @@ class BatchSubSampler:
             )
         traj_idx = valid_trajectories[
             torch.randint(
-                valid_trajectories.numel(), (batch_size,), device=batch.device
+                valid_trajectories.numel(), (batch_size,), device=batch._device_safe()
             )
         ]
 

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -686,7 +686,7 @@ class RewardNormalizer:
         reward = tensordict.get("reward")
 
         reward_device = (
-            reward._device_safe() if hasattr(reward, "_device_safe") else reward.device
+            reward.device_safe() if hasattr(reward, "device_safe") else reward.device
         )
         if reward_device is not None:
             reward = reward - self._reward_stats["mean"].to(reward_device)
@@ -787,7 +787,7 @@ class BatchSubSampler:
         else:
             traj_len = (
                 torch.ones(
-                    batch.shape[0], device=batch._device_safe(), dtype=torch.bool
+                    batch.shape[0], device=batch.device_safe(), dtype=torch.bool
                 )
                 * batch.shape[1]
             )
@@ -803,7 +803,7 @@ class BatchSubSampler:
             )
         traj_idx = valid_trajectories[
             torch.randint(
-                valid_trajectories.numel(), (batch_size,), device=batch._device_safe()
+                valid_trajectories.numel(), (batch_size,), device=batch.device_safe()
             )
         ]
 

--- a/torchrl/trainers/trainers.py
+++ b/torchrl/trainers/trainers.py
@@ -786,9 +786,7 @@ class BatchSubSampler:
             )
         else:
             traj_len = (
-                torch.ones(
-                    batch.shape[0], device=batch.device_safe(), dtype=torch.bool
-                )
+                torch.ones(batch.shape[0], device=batch.device_safe(), dtype=torch.bool)
                 * batch.shape[1]
             )
         len_mask = traj_len >= sub_traj_len


### PR DESCRIPTION
## Description

This PR enables `TensorDict` to be used without a defined device. 

- If the device is defined, all elements must life on the same device, if it is undefined, elements can live on different devices.
- If the `TensorDict` has no device, then adding elements with an explicit device will _not_ set the device on the `TensorDict`. 
- If the `TensorDict` has a defined device, then elements added to the `TensorDict` will be moved to this device.

See `test/test_tensordict.py:test_tensordict_device` for many examples of intended behaviour.

This change required a number of existing code and tests to be updated where either there was an attempt to access `tensordict.device` (which raises a `RuntimeError` if device is not set) or the test relied on the previous behaviour of the `TensorDict` device being set when an element was added.

## Motivation and Context

Closes #394 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

Please advise on whether documentation / example updates are appropriate.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation. (Probably?)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
