### PR TITLE
[Feature] Allow spec to be passed directly to exploration wrappers

### DIFF
--- a/torchrl/modules/tensordict_module/common.py
+++ b/torchrl/modules/tensordict_module/common.py
@@ -192,7 +192,7 @@ class TensorDictModule(nn.Module):
         elif spec is not None and not isinstance(spec, CompositeSpec):
             if len(self.out_keys) > 1:
                 raise RuntimeError(
-                    f"got mode than one out_key for the TensorDictModule: {self.out_keys},\nbut only one spec. "
+                    f"got more than one out_key for the TensorDictModule: {self.out_keys},\nbut only one spec. "
                     "Consider using a CompositeSpec object or no spec at all."
                 )
             spec = CompositeSpec(**{self.out_keys[0]: spec})


### PR DESCRIPTION
## Description

Makes it possible to pass spec directly to exploration wrappers. Also checks that the spec can be found, otherwise throws an exception unless explicitly asked not to.