### PR TITLE
[Naming] Rename _TargetNetUpdate to TargetNetUpdater, making it public

### DIFF
--- a/torchrl/objectives/costs/utils.py
+++ b/torchrl/objectives/costs/utils.py
@@ -88,7 +88,7 @@ class ValueLoss:
     target_value_network: nn.Module
 
 
-class _TargetNetUpdate:
+class TargetNetUpdater:
     """
     An abstract class for target network update in Double DQN/DDPG.
 
@@ -194,7 +194,7 @@ class _TargetNetUpdate:
         return string
 
 
-class SoftUpdate(_TargetNetUpdate):
+class SoftUpdate(TargetNetUpdater):
     """
     A soft-update class for target network update in Double DQN/DDPG.
     This was proposed in "CONTINUOUS CONTROL WITH DEEP REINFORCEMENT LEARNING", https://arxiv.org/pdf/1509.02971.pdf
@@ -222,7 +222,7 @@ class SoftUpdate(_TargetNetUpdate):
         p_target.data.copy_(p_target.data * self.eps + p_source.data * (1 - self.eps))
 
 
-class HardUpdate(_TargetNetUpdate):
+class HardUpdate(TargetNetUpdater):
     """
     A hard-update class for target network update in Double DQN/DDPG (by contrast with soft updates).
     This was proposed in the original Double DQN paper: "Deep Reinforcement Learning with Double Q-learning",

--- a/torchrl/trainers/helpers/losses.py
+++ b/torchrl/trainers/helpers/losses.py
@@ -33,13 +33,13 @@ from torchrl.objectives.costs.deprecated import REDQLoss_deprecated
 
 # from torchrl.objectives.costs.redq import REDQLoss
 
-from torchrl.objectives.costs.utils import _TargetNetUpdate
+from torchrl.objectives.costs.utils import TargetNetUpdater
 from torchrl.objectives.returns.advantages import GAE
 
 
 def make_target_updater(
     cfg: "DictConfig", loss_module: LossModule  # noqa: F821
-) -> Optional[_TargetNetUpdate]:
+) -> Optional[TargetNetUpdater]:
     """Builds a target network weight update object."""
     if cfg.loss == "double":
         if not cfg.hard_update:
@@ -62,7 +62,7 @@ def make_target_updater(
     return target_net_updater
 
 
-def make_sac_loss(model, cfg) -> Tuple[SACLoss, Optional[_TargetNetUpdate]]:
+def make_sac_loss(model, cfg) -> Tuple[SACLoss, Optional[TargetNetUpdater]]:
     """Builds the SAC loss module."""
     loss_kwargs = {}
     if hasattr(cfg, "distributional") and cfg.distributional:
@@ -114,7 +114,7 @@ def make_sac_loss(model, cfg) -> Tuple[SACLoss, Optional[_TargetNetUpdate]]:
 
 def make_redq_loss(
     model, cfg
-) -> Tuple[REDQLoss_deprecated, Optional[_TargetNetUpdate]]:
+) -> Tuple[REDQLoss_deprecated, Optional[TargetNetUpdater]]:
     """Builds the REDQ loss module."""
     loss_kwargs = {}
     if hasattr(cfg, "distributional") and cfg.distributional:
@@ -148,7 +148,7 @@ def make_redq_loss(
     return loss_module, target_net_updater
 
 
-def make_ddpg_loss(model, cfg) -> Tuple[DDPGLoss, Optional[_TargetNetUpdate]]:
+def make_ddpg_loss(model, cfg) -> Tuple[DDPGLoss, Optional[TargetNetUpdater]]:
     """Builds the DDPG loss module."""
     actor, value_net = model
     loss_kwargs = {}
@@ -166,7 +166,7 @@ def make_ddpg_loss(model, cfg) -> Tuple[DDPGLoss, Optional[_TargetNetUpdate]]:
     return loss_module, target_net_updater
 
 
-def make_dqn_loss(model, cfg) -> Tuple[DQNLoss, Optional[_TargetNetUpdate]]:
+def make_dqn_loss(model, cfg) -> Tuple[DQNLoss, Optional[TargetNetUpdater]]:
     """Builds the DQN loss module."""
     loss_kwargs = {}
     if cfg.distributional:

--- a/torchrl/trainers/helpers/trainers.py
+++ b/torchrl/trainers/helpers/trainers.py
@@ -16,7 +16,7 @@ from torchrl.data import ReplayBuffer
 from torchrl.envs.common import EnvBase
 from torchrl.modules import TensorDictModule, TensorDictModuleWrapper, reset_noise
 from torchrl.objectives.costs.common import LossModule
-from torchrl.objectives.costs.utils import _TargetNetUpdate
+from torchrl.objectives.costs.utils import TargetNetUpdater
 from torchrl.trainers.loggers import Logger
 from torchrl.trainers.trainers import (
     Trainer,
@@ -80,7 +80,7 @@ def make_trainer(
     collector: _DataCollector,
     loss_module: LossModule,
     recorder: Optional[EnvBase] = None,
-    target_net_updater: Optional[_TargetNetUpdate] = None,
+    target_net_updater: Optional[TargetNetUpdater] = None,
     policy_exploration: Optional[
         Union[TensorDictModuleWrapper, TensorDictModule]
     ] = None,
@@ -95,7 +95,7 @@ def make_trainer(
         loss_module (LossModule): A TorchRL loss module
         recorder (EnvBase, optional): a recorder environment. If None, the trainer will train the policy without
             testing it.
-        target_net_updater (_TargetNetUpdate, optional): A target network update object.
+        target_net_updater (TargetNetUpdater, optional): A target network update object.
         policy_exploration (TDModule or TensorDictModuleWrapper, optional): a policy to be used for recording and exploration
             updates (should be synced with the learnt policy).
         replay_buffer (ReplayBuffer, optional): a replay buffer to be used to collect data.
@@ -117,7 +117,7 @@ def make_trainer(
         >>> from torchrl.envs.libs.gym import GymEnv
         >>> from torchrl.modules import TensorDictModuleWrapper, TensorDictModule, ValueOperator, EGreedyWrapper
         >>> from torchrl.objectives.costs.common import LossModule
-        >>> from torchrl.objectives.costs.utils import _TargetNetUpdate
+        >>> from torchrl.objectives.costs.utils import TargetNetUpdater
         >>> from torchrl.objectives import DDPGLoss
         >>> env_maker = EnvCreator(lambda: GymEnv("Pendulum-v0"))
         >>> env_proof = env_maker()


### PR DESCRIPTION
## Description

Renamed `_TargetNetUpdate` to `TargetNetUpdater` in `torchrl.objectives.costs.utils`, making it a public class since it is imported by other classes for the purpose of type annotation.

Replaced all references to the above accordingly, including in docstrings.

## Motivation and Context

Addresses #416

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
