### PR TITLE
Make TensorDict.expand accept Sequence arguments

### DIFF
--- a/test/test_tensordict.py
+++ b/test/test_tensordict.py
@@ -760,9 +760,19 @@ class TestTensorDicts:
         torch.manual_seed(1)
         td = getattr(self, td_name)(device)
         batch_size = td.batch_size
+        expected_size = torch.Size([3, *batch_size])
+
         new_td = td.expand(3, *batch_size)
-        assert new_td.batch_size == torch.Size([3, *batch_size])
+        assert new_td.batch_size == expected_size
         assert all((_new_td == td).all() for _new_td in new_td)
+
+        new_td_torch_size = td.expand(expected_size)
+        assert new_td_torch_size.batch_size == expected_size
+        assert all((_new_td == td).all() for _new_td in new_td_torch_size)
+
+        new_td_iterable = td.expand([3, *batch_size])
+        assert new_td_iterable.batch_size == expected_size
+        assert all((_new_td == td).all() for _new_td in new_td_iterable)
 
     def test_cast(self, td_name, device):
         torch.manual_seed(1)

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -670,9 +670,10 @@ dtype=torch.float32)},
 
         raise NotImplementedError(f"{self.__class__.__name__}")
 
-    def expand(self, *shape: int) -> TensorDictBase:
+    def expand(self, *shape) -> TensorDictBase:
         """Expands each tensors of the tensordict according to
         `tensor.expand(*shape, *tensor.shape)`
+        Supports iterables to specify the shape
 
         Examples:
             >>> td = TensorDict(source={'a': torch.zeros(3, 4, 5),
@@ -683,6 +684,9 @@ dtype=torch.float32)},
         """
         d = dict()
         tensordict_dims = self.batch_dims
+
+        if len(shape) == 1 and isinstance(shape[0], Sequence):
+            shape = tuple(shape[0])
 
         # new shape dim check
         if len(shape) < len(self.shape):
@@ -1990,12 +1994,16 @@ class TensorDict(TensorDictBase):
                     self.set(key, value.pin_memory(), inplace=False)
         return self
 
-    def expand(self, *shape: int) -> TensorDictBase:
+    def expand(self, *shape) -> TensorDictBase:
         """Expands every tensor with `(*shape, *tensor.shape)` and returns the
         same tensordict with new tensors with expanded shapes.
+        Supports iterables to specify the shape.
         """
         d = dict()
         tensordict_dims = self.batch_dims
+
+        if len(shape) == 1 and isinstance(shape[0], Sequence):
+            shape = tuple(shape[0])
 
         # new shape dim check
         if len(shape) < len(self.shape):
@@ -3002,7 +3010,10 @@ torch.Size([3, 2])
             return self
         return self._source.select(*keys)[self.idx]
 
-    def expand(self, *shape: int, inplace: bool = False) -> TensorDictBase:
+    def expand(self, *shape, inplace: bool = False) -> TensorDictBase:
+        if len(shape) == 1 and isinstance(shape[0], Sequence):
+            shape = tuple(shape[0])
+
         idx = self.idx
         if isinstance(idx, torch.Tensor) and idx.dtype is torch.double:
             # check that idx is not a mask, otherwise throw an error
@@ -3015,7 +3026,6 @@ torch.Size([3, 2])
             idx = idx + (slice(None),) * (self._source.ndimension() - len(idx))
         # now that idx has the same length as the source's number of dims, we can work with it
 
-        # print("shape", shape)
         source_shape = self._source.shape
         num_integer_types = 0
         for i in idx:
@@ -3050,7 +3060,6 @@ torch.Size([3, 2])
                 new_idx.append(_idx)
                 new_source_shape.append(shape[0])
                 shape = shape[1:]
-        # print("source shape", source_shape, "\nnew source shape", new_source_shape, "\nidx", idx, "\nnew_idx", new_idx)
         assert not len(shape)
         new_source = self._source.expand(*new_source_shape)
         new_idx = tuple(new_idx)
@@ -3612,7 +3621,9 @@ class LazyStackedTensorDict(TensorDictBase):
         self.is_locked = lock
         return self
 
-    def expand(self, *shape: int, inplace: bool = False) -> TensorDictBase:
+    def expand(self, *shape, inplace: bool = False) -> TensorDictBase:
+        if len(shape) == 1 and isinstance(shape[0], Sequence):
+            shape = tuple(shape[0])
         stack_dim = len(shape) + self.stack_dim - self.ndimension()
         new_shape_tensordicts = [v for i, v in enumerate(shape) if i != stack_dim]
         tensordicts = [td.expand(*new_shape_tensordicts) for td in self.tensordicts]
@@ -3797,7 +3808,9 @@ class SavedTensorDict(TensorDictBase):
         self._save(td)
         return self
 
-    def expand(self, *shape: int, inplace: bool = False) -> TensorDictBase:
+    def expand(self, *shape, inplace: bool = False) -> TensorDictBase:
+        if len(shape) == 1 and isinstance(shape[0], Sequence):
+            shape = tuple(shape[0])
         td = self._load()
         td = td.expand(*shape)
         if inplace:


### PR DESCRIPTION
## Description

Enable use of arguments of subclasses of `Sequence` to specify the desired shape for `TensorDict.expand`

## Motivation and Context

close #417 

- [x] I have raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)
- [x] Documentation (update in the documentation)

## Checklist

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
