### PR TITLE
Explicit params and buffers

### DIFF
--- a/torchrl/modules/tensordict_module/common.py
+++ b/torchrl/modules/tensordict_module/common.py
@@ -335,7 +335,7 @@ class TensorDictModule(nn.Module):
             kwargs_pruned = {
                 key: item
                 for key, item in kwargs.items()
-                if key not in ("params", "buffers", "vmap")
+                if key not in ("params", "vmap")
             }
             out = module(kwargs["params"], *tensors, **kwargs_pruned)
             return out
@@ -353,18 +353,10 @@ class TensorDictModule(nn.Module):
                 for key, item in kwargs.items()
                 if key not in ("params", "buffers", "vmap")
             }
-            print('kwargs["params"]', kwargs["params"])
-            print('kwargs["buffers"]', kwargs["buffers"])
-            print("tensors", tensors)
             out = module(kwargs["params"], kwargs["buffers"], *tensors, **kwargs_pruned)
             return out
         else:
-            kwargs_pruned = {
-                key: item
-                for key, item in kwargs.items()
-                if key not in ("params", "buffers")
-            }
-            out = self.module(*tensors, **kwargs_pruned)
+            out = self.module(*tensors, **kwargs)
         return out
 
     def forward(
@@ -373,11 +365,8 @@ class TensorDictModule(nn.Module):
         tensordict_out: Optional[TensorDictBase] = None,
         **kwargs,
     ) -> TensorDictBase:
-        # print("kwargs", kwargs)
-        print("Calling forward", tensordict)
         tensors = tuple(tensordict.get(in_key, None) for in_key in self.in_keys)
         tensors = self._call_module(tensors, **kwargs)
-        print("Called _call_module")
         if not isinstance(tensors, tuple):
             tensors = (tensors,)
         tensordict_out = self._write_to_tensordict(

--- a/torchrl/modules/tensordict_module/common.py
+++ b/torchrl/modules/tensordict_module/common.py
@@ -335,7 +335,7 @@ class TensorDictModule(nn.Module):
             kwargs_pruned = {
                 key: item
                 for key, item in kwargs.items()
-                if key not in ("params", "vmap")
+                if key not in ("params", "buffers", "vmap")
             }
             out = module(kwargs["params"], *tensors, **kwargs_pruned)
             return out
@@ -353,10 +353,18 @@ class TensorDictModule(nn.Module):
                 for key, item in kwargs.items()
                 if key not in ("params", "buffers", "vmap")
             }
+            print('kwargs["params"]', kwargs["params"])
+            print('kwargs["buffers"]', kwargs["buffers"])
+            print("tensors", tensors)
             out = module(kwargs["params"], kwargs["buffers"], *tensors, **kwargs_pruned)
             return out
         else:
-            out = self.module(*tensors, **kwargs)
+            kwargs_pruned = {
+                key: item
+                for key, item in kwargs.items()
+                if key not in ("params", "buffers")
+            }
+            out = self.module(*tensors, **kwargs_pruned)
         return out
 
     def forward(
@@ -365,8 +373,11 @@ class TensorDictModule(nn.Module):
         tensordict_out: Optional[TensorDictBase] = None,
         **kwargs,
     ) -> TensorDictBase:
+        # print("kwargs", kwargs)
+        print("Calling forward", tensordict)
         tensors = tuple(tensordict.get(in_key, None) for in_key in self.in_keys)
         tensors = self._call_module(tensors, **kwargs)
+        print("Called _call_module")
         if not isinstance(tensors, tuple):
             tensors = (tensors,)
         tensordict_out = self._write_to_tensordict(

--- a/torchrl/modules/tensordict_module/sequence.py
+++ b/torchrl/modules/tensordict_module/sequence.py
@@ -439,7 +439,7 @@ class TensorDictSequence(TensorDictModule):
         **kwargs,
     ) -> Tuple[torch.distributions.Distribution, ...]:
         L = len(self.module)
-        
+
         if isinstance(self.module[-1], ProbabilisticTensorDictModule):
             if "params" in kwargs and "buffers" in kwargs:
                 params = kwargs["params"]

--- a/torchrl/modules/tensordict_module/sequence.py
+++ b/torchrl/modules/tensordict_module/sequence.py
@@ -331,7 +331,7 @@ class TensorDictSequence(TensorDictModule):
         elif not len(kwargs):
             for module in self.module:
                 tensordict = self._run_module(
-                    module, tensordict, params=(), buffers=(), **kwargs
+                    module, tensordict, **kwargs
                 )
         else:
             raise RuntimeError(

--- a/torchrl/modules/tensordict_module/sequence.py
+++ b/torchrl/modules/tensordict_module/sequence.py
@@ -439,6 +439,7 @@ class TensorDictSequence(TensorDictModule):
         **kwargs,
     ) -> Tuple[torch.distributions.Distribution, ...]:
         L = len(self.module)
+        
         if isinstance(self.module[-1], ProbabilisticTensorDictModule):
             if "params" in kwargs and "buffers" in kwargs:
                 params = kwargs["params"]

--- a/torchrl/modules/tensordict_module/sequence.py
+++ b/torchrl/modules/tensordict_module/sequence.py
@@ -439,7 +439,6 @@ class TensorDictSequence(TensorDictModule):
         **kwargs,
     ) -> Tuple[torch.distributions.Distribution, ...]:
         L = len(self.module)
-        print("get_dist", kwargs)
         if isinstance(self.module[-1], ProbabilisticTensorDictModule):
             if "params" in kwargs and "buffers" in kwargs:
                 params = kwargs["params"]


### PR DESCRIPTION
## Description

Added params and buffers as explicit arguments to the forward functions.

## Motivation and Context

Motivation
For functional evaluation, we pass the module params (and possibly buffers) together with the inputs of the module (stored in a TensorDict) using

def forward(self, tensordict, **kwargs):
    params = kwargs.get("params", None)
    buffers = kwargs.get("buffers", None)
    ...
However, this breaks when using [higher](https://github.com/facebookresearch/higher).

We should have default values for these instead of using get("params", None) etc.

The changes should be compatible with: TensorDictModule, TensorDictSequence and ProbabilisticTensorDict.

close #419 

- [ ] I have raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
