### PR TITLE
[Refactor] Refactoring `set*()` methods for `TensorDictBase` class

### DIFF
--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -556,15 +556,22 @@ dtype=torch.float32)},
     def _convert_to_tensor(self, array: np.ndarray) -> Union[Tensor, MemmapTensor]:
         return torch.as_tensor(array, device=self.device_safe())
 
-    def _process_tensor(
+    def _convert_to_tensordict(self, dict_value: dict) -> TensorDictBase:
+        return TensorDict(
+                    dict_value, batch_size=self.batch_size, device=self.device_safe()
+                )
+
+    def _process_input(
         self,
-        input: Union[COMPATIBLE_TYPES, np.ndarray],
+        input: Union[COMPATIBLE_TYPES, dict, np.ndarray],
         check_device: bool = True,
         check_tensor_shape: bool = True,
         check_shared: bool = False,
     ) -> Union[Tensor, MemmapTensor]:
 
-        if not isinstance(input, _accepted_classes):
+        if isinstance(input, dict):
+            tensor = self._convert_to_tensordict(input)
+        elif not isinstance(input, _accepted_classes):
             tensor = self._convert_to_tensor(input)
         else:
             tensor = input
@@ -2060,16 +2067,13 @@ class TensorDict(TensorDictBase):
         """Sets a value in the TensorDict. If inplace=True (default is False),
         and if the key already exists, set will call set_ (in place setting).
         """
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if self.is_locked:
             if not inplace or key not in self.keys():
                 raise RuntimeError("Cannot modify locked TensorDict")
         if not isinstance(key, str):
             raise TypeError(f"Expected key to be a string but found {type(key)}")
 
+        # TODO Handle ._is_shared
         if self._is_shared is None:
             try:
                 self._is_shared = value.is_shared()
@@ -2085,7 +2089,7 @@ class TensorDict(TensorDictBase):
 
         if present and inplace:
             return self.set_(key, value)
-        proc_value = self._process_tensor(
+        proc_value = self._process_input(
             value,
             check_tensor_shape=_run_checks,
             check_shared=False,
@@ -2130,17 +2134,13 @@ class TensorDict(TensorDictBase):
     def set_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if not no_check:
             if not isinstance(key, str):
                 raise TypeError(f"Expected key to be a string but found {type(key)}")
 
         if no_check or key in self.keys():
             if not no_check:
-                proc_value = self._process_tensor(
+                proc_value = self._process_input(
                     value, check_device=False, check_shared=False
                 )
                 # copy_ will broadcast one tensor onto another's shape, which we don't want
@@ -2195,17 +2195,14 @@ class TensorDict(TensorDictBase):
     def set_at_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if not isinstance(key, str):
             raise TypeError(f"Expected key to be a string but found {type(key)}")
 
         # do we need this?
-        # value = self._process_tensor(
-        #     value, check_tensor_shape=False, check_device=False
-        # )
+        if isinstance(value, dict):
+            value = self._process_input(
+                value, check_tensor_shape=False, check_device=False
+            )
         if key not in self.keys():
             raise KeyError(f"did not find key {key} in {self.__class__.__name__}")
         tensor_in = self._tensordict[key]
@@ -2859,16 +2856,10 @@ torch.Size([3, 2])
         inplace: bool = False,
         _run_checks: bool = True,
     ) -> TensorDictBase:
-        if isinstance(tensor, dict):
-            tensor = TensorDict(
-                tensor, batch_size=self.batch_size, device=self.device_safe()
-            )
         keys = set(self.keys())
         if self.is_locked:
             if not inplace or key not in keys:
                 raise RuntimeError("Cannot modify locked TensorDict")
-        if isinstance(tensor, TensorDictBase) and tensor.batch_size != self.batch_size:
-            tensor.batch_size = self.batch_size
         if inplace and key in keys:
             return self.set_(key, tensor)
         elif key in keys:
@@ -2877,9 +2868,11 @@ torch.Size([3, 2])
                 "Consider calling `SubTensorDict.set_(...)` or cloning your tensordict first."
             )
 
-        tensor = self._process_tensor(
+        tensor = self._process_input(
             tensor, check_device=False, check_tensor_shape=False
         )
+        if isinstance(tensor, TensorDictBase) and tensor.batch_size != self.batch_size:
+            tensor.batch_size = self.batch_size
         parent = self.get_parent_tensordict()
 
         if isinstance(tensor, TensorDictBase):
@@ -2916,21 +2909,18 @@ torch.Size([3, 2])
     def set_(
         self, key: str, tensor: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
     ) -> SubTensorDict:
-        if isinstance(tensor, dict):
-            tensor = TensorDict(
-                tensor, batch_size=self.batch_size, device=self.device_safe()
-            )
         if not no_check:
+            tensor = self._process_input(
+                tensor, check_device=False, check_tensor_shape=False
+            )
             if key not in self.keys():
                 raise KeyError(f"key {key} not found in {self.keys()}")
-            if tensor.shape[: self.batch_dims] != self.batch_size:
+            if not isinstance(tensor, dict) and tensor.shape[: self.batch_dims] != self.batch_size:
                 raise RuntimeError(
                     f"tensor.shape={tensor.shape[:self.batch_dims]} and "
                     f"self.batch_size={self.batch_size} mismatch"
                 )
-        tensor = self._process_tensor(
-            tensor, check_device=False, check_tensor_shape=False
-        )
+
         self._source.set_at_(key, tensor, self.idx)
         if key in self._dict_meta:
             self._dict_meta[key].requires_grad = tensor.requires_grad
@@ -2991,10 +2981,6 @@ torch.Size([3, 2])
         idx: INDEX_TYPING,
         discard_idx_attr: bool = False,
     ) -> SubTensorDict:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if not isinstance(idx, tuple):
             idx = (idx,)
         if discard_idx_attr:
@@ -3003,6 +2989,7 @@ torch.Size([3, 2])
             tensor = self._source.get_at(key, self.idx)
             tensor[idx] = value
             self._source.set_at_(key, tensor, self.idx)
+        # TODO Handle value.requires_grad
         if key in self._dict_meta:
             self._dict_meta[key].requires_grad = value.requires_grad
         return self
@@ -3366,13 +3353,13 @@ class LazyStackedTensorDict(TensorDictBase):
     def set(
         self, key: str, tensor: Union[dict, COMPATIBLE_TYPES], **kwargs
     ) -> TensorDictBase:
-        if isinstance(tensor, dict):
-            tensor = TensorDict(
-                tensor, batch_size=self.batch_size, device=self.device_safe()
-            )
         if self.is_locked:
             if key not in self.keys():
                 raise RuntimeError("Cannot modify locked TensorDict")
+
+        tensor = self._process_input(
+            tensor, check_device=False, check_tensor_shape=False
+        )
         if isinstance(tensor, TensorDictBase):
             if tensor.batch_size[: self.batch_dims] != self.batch_size:
                 tensor.batch_size = self.clone(recurse=False).batch_size
@@ -3382,10 +3369,8 @@ class LazyStackedTensorDict(TensorDictBase):
                 f"mismatch: got tensor.shape = {tensor.shape} and "
                 f"tensordict.batch_size={self.batch_size}"
             )
-        proc_tensor = self._process_tensor(
-            tensor, check_device=False, check_tensor_shape=False
-        )
-        proc_tensor = proc_tensor.unbind(self.stack_dim)
+
+        proc_tensor = tensor.unbind(self.stack_dim)
         for td, _item in zip(self.tensordicts, proc_tensor):
             td.set(key, _item, **kwargs)
         if key not in self._valid_keys:
@@ -3397,11 +3382,13 @@ class LazyStackedTensorDict(TensorDictBase):
     def set_(
         self, key: str, tensor: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
     ) -> TensorDictBase:
-        if isinstance(tensor, dict):
-            tensor = TensorDict(
-                tensor, batch_size=self.batch_size, device=self.device_safe()
-            )
         if not no_check:
+            tensor = self._process_input(
+                tensor,
+                check_device=False,
+                check_tensor_shape=False,
+                check_shared=False,
+            )
             if isinstance(tensor, TensorDictBase):
                 if tensor.batch_size[: self.batch_dims] != self.batch_size:
                     tensor.batch_size = self.clone(recurse=False).batch_size
@@ -3417,12 +3404,6 @@ class LazyStackedTensorDict(TensorDictBase):
                     "permitted if all members of the stack have this key in "
                     "their register."
                 )
-            tensor = self._process_tensor(
-                tensor,
-                check_device=False,
-                check_tensor_shape=False,
-                check_shared=False,
-            )
         if key in self._dict_meta:
             self._dict_meta[key].requires_grad = tensor.requires_grad
         tensors = tensor.unbind(self.stack_dim)
@@ -3433,10 +3414,6 @@ class LazyStackedTensorDict(TensorDictBase):
     def set_at_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         sub_td = self[idx]
         sub_td.set_(key, value)
         return self
@@ -3907,10 +3884,6 @@ class SavedTensorDict(TensorDictBase):
     def set(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], **kwargs
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if self.is_locked:
             if key not in self.keys():
                 raise RuntimeError("Cannot modify locked TensorDict")
@@ -3943,20 +3916,12 @@ class SavedTensorDict(TensorDictBase):
     def set_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         self.set(key, value)
         return self
 
     def set_at_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         td = self._load()
         td.set_at_(key, value, idx)
         self._save(td)
@@ -4312,10 +4277,6 @@ class _CustomOpTensorDict(TensorDictBase):
     def set(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], **kwargs
     ) -> TensorDictBase:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if self.inv_op is None:
             raise Exception(
                 f"{self.__class__.__name__} does not support setting values. "
@@ -4324,7 +4285,7 @@ class _CustomOpTensorDict(TensorDictBase):
         if self.is_locked:
             if key not in self.keys():
                 raise RuntimeError("Cannot modify locked TensorDict")
-        proc_value = self._process_tensor(
+        proc_value = self._process_input(
             value,
             check_device=False,
             check_tensor_shape=True,
@@ -4338,10 +4299,6 @@ class _CustomOpTensorDict(TensorDictBase):
     def set_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], no_check: bool = False
     ) -> _CustomOpTensorDict:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         if not no_check:
             if self.inv_op is None:
                 raise Exception(
@@ -4355,10 +4312,6 @@ class _CustomOpTensorDict(TensorDictBase):
     def set_at_(
         self, key: str, value: Union[dict, COMPATIBLE_TYPES], idx: INDEX_TYPING
     ) -> _CustomOpTensorDict:
-        if isinstance(value, dict):
-            value = TensorDict(
-                value, batch_size=self.batch_size, device=self.device_safe()
-            )
         transformed_tensor, original_tensor = self.get(
             key, _return_original_tensor=True
         )

--- a/torchrl/data/tensordict/tensordict.py
+++ b/torchrl/data/tensordict/tensordict.py
@@ -558,8 +558,8 @@ dtype=torch.float32)},
 
     def _convert_to_tensordict(self, dict_value: dict) -> TensorDictBase:
         return TensorDict(
-                    dict_value, batch_size=self.batch_size, device=self.device_safe()
-                )
+            dict_value, batch_size=self.batch_size, device=self.device_safe()
+        )
 
     def _process_input(
         self,
@@ -2915,7 +2915,10 @@ torch.Size([3, 2])
             )
             if key not in self.keys():
                 raise KeyError(f"key {key} not found in {self.keys()}")
-            if not isinstance(tensor, dict) and tensor.shape[: self.batch_dims] != self.batch_size:
+            if (
+                not isinstance(tensor, dict)
+                and tensor.shape[: self.batch_dims] != self.batch_size
+            ):
                 raise RuntimeError(
                     f"tensor.shape={tensor.shape[:self.batch_dims]} and "
                     f"self.batch_size={self.batch_size} mismatch"


### PR DESCRIPTION
## Description

For all the `TensorDictBase` child classes, refactoring `set*()` methods, so that `dict -> TensorDict` casting happens only in `_process_input()`. 

## Motivation and Context
Removing duplicate code and making it consistent across the child classes.
close #431 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).