### PR TITLE
[CI, Doc] Update functorch source installation command

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -33,12 +33,6 @@ else
     pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 fi
 
-printf "Installing functorch\n"
-pip3 install ninja  # Makes the build go faster
-#pip3 install "git+https://github.com/pytorch/functorch.git"
-PYTORCH_VERSION=`python -c "import torch.version; print(torch.version.git_version)"`
-pip install "git+https://github.com/pytorch/pytorch.git@$PYTORCH_VERSION#subdirectory=functorch"
-
 # smoke test
 python -c "import functorch"
 

--- a/.circleci/unittest/linux_optdeps/scripts/install.sh
+++ b/.circleci/unittest/linux_optdeps/scripts/install.sh
@@ -35,12 +35,6 @@ else
     pip3 install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu113
 fi
 
-printf "Installing functorch\n"
-python -m pip install ninja  # Makes the build go faster
-#python -m pip install "git+https://github.com/pytorch/functorch.git"
-PYTORCH_VERSION=`python -c "import torch.version; print(torch.version.git_version)"`
-pip install "git+https://github.com/pytorch/pytorch.git@$PYTORCH_VERSION#subdirectory=functorch"
-
 # smoke test
 python -c "import functorch"
 

--- a/README.md
+++ b/README.md
@@ -375,29 +375,7 @@ pip3 install --pre torch torchvision --extra-index-url https://download.pytorch.
 pip3 install --pre torch torchvision --extra-index-url https://download.pytorch.org/whl/nightly/cpu
 ```
 
-and functorch
-```
-pip3 install ninja  # Makes the build go faster
-pip3 install "git+https://github.com/pytorch/functorch.git"
-```
-
-If this fails, you can get the latest version of functorch that was marked to be
-compatible with the current torch version:
-```bash
-pip3 install ninja  # Makes the build go faster
-PYTORCH_VERSION=`python -c "import torch.version; print(torch.version.git_version)"`
-pip3 install "git+https://github.com/pytorch/pytorch.git@$PYTORCH_VERSION#subdirectory=functorch"
-```
-
-If the generation of this artifact in MacOs M1 doesn't work correctly or in the execution the message
-`(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e'))` appears,
-try erasing the previously created build artifacts (`torchrl.egg-info/`, `build/`, `torchrl/_torchsl.so`)
-or re-clone the library from GitHub, then try
-
-```
-PYTORCH_VERSION=`python -c "import torch.version; print(torch.version.git_version)"`
-ARCHFLAGS="-arch arm64" pip3 install "git+https://github.com/pytorch/pytorch.git@$PYTORCH_VERSION#subdirectory=functorch"
-```
+functorch is included in the nightly PyTorch package, so no need to install it separately.
 
 **Torchrl**
 


### PR DESCRIPTION
We changed how one installs functorch: functorch is now included in the PyTorch binary. This PR removes the old installation command which effectively does nothing right now. We'll be removing support for the old installation command after we migrate people off of it.

Test Plan:
- wait for CI
