### PR TITLE
[Feature]: Added TensorDictDefaultInitializer

### DIFF
--- a/test/test_tensordictmodules.py
+++ b/test/test_tensordictmodules.py
@@ -7,6 +7,7 @@ import argparse
 
 import pytest
 import torch
+from _utils_internal import get_available_devices
 from functorch import make_functional, make_functional_with_buffers
 from torch import nn
 from torchrl.data import TensorDict
@@ -21,6 +22,7 @@ from torchrl.modules import (
     TanhNormal,
     NormalParamWrapper,
 )
+from torchrl.modules.tensordict_module.initializer import TensorDictDefaultInitializer
 from torchrl.modules.tensordict_module.probabilistic import (
     ProbabilisticTensorDictModule,
 )
@@ -133,7 +135,7 @@ class TestTDModule:
                     dist_param_keys=dist_param_keys,
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -143,7 +145,7 @@ class TestTDModule:
                 dist_param_keys=dist_param_keys,
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
@@ -249,7 +251,7 @@ class TestTDModule:
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -259,7 +261,7 @@ class TestTDModule:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
 
         td = TensorDict({"in": torch.randn(3, 3)}, [3])
@@ -312,7 +314,7 @@ class TestTDModule:
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -322,7 +324,7 @@ class TestTDModule:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
         tensordict_module, (
             params,
@@ -431,7 +433,7 @@ class TestTDModule:
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -441,7 +443,7 @@ class TestTDModule:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
 
         td = TensorDict({"in": torch.randn(3, 32 * param_multiplier)}, [3])
@@ -494,7 +496,7 @@ class TestTDModule:
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -504,7 +506,7 @@ class TestTDModule:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
         tdmodule, (params, buffers) = tdmodule.make_functional_with_buffers()
 
@@ -635,7 +637,7 @@ class TestTDModule:
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -645,7 +647,7 @@ class TestTDModule:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
 
         # vmap = True
@@ -723,7 +725,7 @@ class TestTDModule:
                     dist_param_keys=["loc", "scale"],
                     out_key_sample=["out"],
                     safe=safe,
-                    **kwargs
+                    **kwargs,
                 )
             return
         else:
@@ -733,7 +735,7 @@ class TestTDModule:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
         tdmodule, (params, buffers) = tdmodule.make_functional_with_buffers()
 
@@ -836,7 +838,7 @@ class TestTDSequence:
                 in_keys=["hidden"],
                 out_keys=["out"],
                 safe=False,
-                **kwargs
+                **kwargs,
             )
             tdmodule = TensorDictSequence(tdmodule1, dummy_tdmodule, tdmodule2)
 
@@ -924,7 +926,7 @@ class TestTDSequence:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=False,
-                **kwargs
+                **kwargs,
             )
             tdmodule = TensorDictSequence(tdmodule1, dummy_tdmodule, tdmodule2)
 
@@ -1080,7 +1082,7 @@ class TestTDSequence:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
             tdmodule = TensorDictSequence(tdmodule1, dummy_tdmodule, tdmodule2)
 
@@ -1253,7 +1255,7 @@ class TestTDSequence:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
             tdmodule = TensorDictSequence(tdmodule1, dummy_tdmodule, tdmodule2)
 
@@ -1329,7 +1331,7 @@ class TestTDSequence:
                 dist_param_keys=["loc", "scale"],
                 out_key_sample=["out"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
             tdmodule = TensorDictSequence(tdmodule1, tdmodule2)
 
@@ -1494,7 +1496,7 @@ class TestTDSequence:
                 out_key_sample=["out"],
                 dist_param_keys=["loc", "scale"],
                 safe=safe,
-                **kwargs
+                **kwargs,
             )
             tdmodule = TensorDictSequence(tdmodule1, tdmodule2)
 
@@ -1630,7 +1632,7 @@ class TestTDSequence:
             out_key_sample=["out"],
             dist_param_keys=["loc", "scale"],
             safe=True,
-            **kwargs
+            **kwargs,
         )
         tdmodule3 = ProbabilisticTensorDictModule(
             fnet3,
@@ -1638,7 +1640,7 @@ class TestTDSequence:
             out_key_sample=["out"],
             dist_param_keys=["loc", "scale"],
             safe=True,
-            **kwargs
+            **kwargs,
         )
         tdmodule = TensorDictSequence(
             tdmodule1, tdmodule2, tdmodule3, partial_tolerant=True
@@ -1700,6 +1702,100 @@ class TestTDSequence:
 
         assert not torch.allclose(copy, sub_seq_1[0].module.weight)
         assert torch.allclose(td_module[0].module.weight, sub_seq_1[0].module.weight)
+
+
+class TestTensorDictDefaultInitializer:
+    @pytest.mark.parametrize("device", get_available_devices())
+    @pytest.mark.parametrize("batch_size", [[], [3], [5], [2, 3]])
+    @pytest.mark.parametrize("initializer", [torch.zeros, torch.ones, torch.randn])
+    @pytest.mark.parametrize("num_new_tensors", [1, 2, 3])
+    def test_td_initializer(self, device, batch_size, initializer, num_new_tensors):
+        td = TensorDict(
+            {"a": torch.randn(*batch_size, 3), "b": torch.randn(*batch_size, 4)},
+            batch_size,
+        ).to(device)
+        td_ref = td.clone()
+        default_td = {
+            f"c_{i}": {"initializer": initializer, "shape": [2]}
+            for i in range(num_new_tensors)
+        }
+        initializer = TensorDictDefaultInitializer(default_td).to(device)
+        td = initializer(td)
+
+        assert torch.allclose(td["a"], td_ref["a"])
+        assert torch.allclose(td["b"], td_ref["b"])
+        for i in range(num_new_tensors):
+            assert f"c_{i}" in td.keys()
+            assert td[f"c_{i}"].shape == torch.Size([*batch_size, 2])
+            assert td[f"c_{i}"].device == device
+
+    @pytest.mark.parametrize("batch_size", [[], [3], [5], [2, 3]])
+    @pytest.mark.parametrize("initializer", [torch.zeros, torch.ones, torch.randn])
+    @pytest.mark.parametrize("num_new_tensors", [1, 2, 3])
+    def test_td_initializer_no_device(self, batch_size, initializer, num_new_tensors):
+        td = TensorDict(
+            {"a": torch.randn(*batch_size, 3), "b": torch.randn(*batch_size, 4)},
+            batch_size,
+        )
+        td_ref = td.clone()
+        default_td = {
+            f"c_{i}": {"initializer": initializer, "shape": [2]}
+            for i in range(num_new_tensors)
+        }
+        initializer = TensorDictDefaultInitializer(default_td)
+        td = initializer(td)
+
+        assert torch.allclose(td["a"], td_ref["a"])
+        assert torch.allclose(td["b"], td_ref["b"])
+        for i in range(num_new_tensors):
+            assert f"c_{i}" in td.keys()
+            assert td[f"c_{i}"].shape == torch.Size([*batch_size, 2])
+
+    @pytest.mark.parametrize("device", get_available_devices())
+    @pytest.mark.parametrize("initializer", [torch.zeros, torch.ones, torch.randn])
+    def test_td_initializer_reinit(self, device, initializer):
+        td = TensorDict({"a": torch.randn(5, 3), "b": torch.randn(5, 4)}, [5]).to(
+            device
+        )
+        td_ref = td.clone()
+        default_td = {
+            "b": {"initializer": initializer, "shape": [4]},
+            "c": {"initializer": initializer, "shape": [2]},
+        }
+        initializer = TensorDictDefaultInitializer(default_td, reinit=True).to(device)
+        td = initializer(td)
+
+        assert torch.allclose(td["a"], td_ref["a"])
+        assert not torch.allclose(td["b"], td_ref["b"])
+        assert "c" in td.keys()
+        assert td["b"].shape == torch.Size([5, 4])
+        assert td["c"].shape == torch.Size([5, 2])
+
+    @pytest.mark.parametrize("device", get_available_devices())
+    @pytest.mark.parametrize("batch_size", [[], [3], [5], [2, 3]])
+    @pytest.mark.parametrize("initializer", [torch.zeros, torch.ones, torch.randn])
+    def test_td_initializer_in_tdsequence(self, device, batch_size, initializer):
+        td = TensorDict(
+            {"a": torch.randn(*batch_size, 3), "b": torch.randn(*batch_size, 4)},
+            batch_size,
+        ).to(device)
+        td_ref = td.clone()
+        default_td = {"c": {"initializer": initializer, "shape": [2]}}
+        initializer = TensorDictDefaultInitializer(default_td)
+        td_seq = TensorDictSequence(
+            initializer,
+            TensorDictModule(nn.Linear(2, 10), in_keys=["c"], out_keys=["d"]),
+        ).to(device)
+        td = td_seq(td)
+
+        assert torch.allclose(td["a"], td_ref["a"])
+        assert torch.allclose(td["b"], td_ref["b"])
+        assert "c" in td.keys()
+        assert td["c"].shape == torch.Size([*batch_size, 2])
+        assert td["c"].device == device
+        assert "d" in td.keys()
+        assert td["d"].shape == torch.Size([*batch_size, 10])
+        assert td["d"].device == device
 
     if __name__ == "__main__":
         args, unknown = argparse.ArgumentParser().parse_known_args()

--- a/torchrl/modules/tensordict_module/__init__.py
+++ b/torchrl/modules/tensordict_module/__init__.py
@@ -8,3 +8,4 @@ from .common import *
 from .exploration import *
 from .sequence import *
 from .probabilistic import *
+from .initializer import *

--- a/torchrl/modules/tensordict_module/initializer.py
+++ b/torchrl/modules/tensordict_module/initializer.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Union,
+)
+
+from torchrl.modules.tensordict_module.common import TensorDictModule
+
+from torch import nn, Tensor
+
+from torchrl.data.tensordict.tensordict import TensorDict, TensorDictBase
+
+class _DefaultInitializer(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, initializer_dict: dict, batch_size, device) -> dict:
+        outputs = {}
+        for key, value in initializer_dict.items():
+            if "args" in value and "kwargs" in value:
+                outputs[key] = value["initializer"]( *batch_size, *value["shape"],
+                        *value["args"], **value["kwargs"], device=device
+                )
+            elif "args" in value:
+                outputs[key] = value["initializer"]( *batch_size, *value["shape"],
+                        *value["args"], device=device
+                )
+            elif "kwargs" in value:
+                outputs[key] = value["initializer"]( *batch_size, *value["shape"],
+                        **value["kwargs"], device=device
+                )
+            else:
+                outputs[key] = value["initializer"]( *batch_size, *value["shape"], device=device)
+        return outputs
+
+class TensorDictDefaultInitializer(TensorDictModule):
+    """
+    TensorDictDefaultInitializer
+    This module is meant to initialize missing values in a TensorDict.
+    It takes a dictionary of default parameters and initializes the TensorDict with them.
+
+    Args:
+        defaults_init (Dict[Dict]): Dictionary of default parameters to initialize the TensorDict with.
+            Takes the form of {key: {"initializer": initializer, "shape": shape, "args": args, "kwargs": kwargs}}
+            with key key associated with the tensor to be initialized, initializer the initializer function,
+            shape the shape of the tensor, args the positional arguments to pass to the initializer function,
+            and kwargs the keyword arguments to pass to the initializer function.
+            the initializer function must be of the following form initializer (*batch_size, *args, **kwargs, device=device)
+        reinit (bool): Whether to reinitialize already initialized tensors.
+    
+    Returns:
+        TensorDictBase: The TensorDict to whom we added the initialized tensors.
+
+
+    """
+    def __init__(
+        self,
+        defaults_init: Dict[Dict],
+        reinit = False,
+    ):
+
+        module = _DefaultInitializer()
+
+        in_keys = []
+        out_keys = defaults_init.keys()
+        self.reinit = reinit
+
+        self.defaults_init = defaults_init
+
+        super().__init__(module, in_keys, out_keys)
+
+    def forward(
+        self,
+        tensordict: TensorDictBase,
+        tensordict_out: Optional[TensorDictBase] = None,
+        params: Optional[Union[TensorDictBase, List[Tensor]]] = None,
+        buffers: Optional[Union[TensorDictBase, List[Tensor]]] = None,
+        **kwargs,
+    ) -> TensorDictBase:
+        batch_size = tensordict.batch_size
+        device = tensordict.device_safe()
+        tensors = self.module(self.defaults_init, batch_size, device)
+        if not self.reinit:
+            tensors = {k: v for k, v in tensors.items() if k not in tensordict}
+        new_tensors_td = TensorDict(tensors, batch_size=batch_size)
+        if tensordict_out is None:
+            tensordict_out = tensordict
+        tensordict_out.update(new_tensors_td)
+        return tensordict_out

--- a/torchrl/modules/tensordict_module/initializer.py
+++ b/torchrl/modules/tensordict_module/initializer.py
@@ -17,14 +17,15 @@ from typing import (
     Union,
 )
 
-from torchrl.modules.tensordict_module.common import TensorDictModule
-
 from torch import nn, Tensor
 
 from torchrl.data.tensordict.tensordict import TensorDict, TensorDictBase
+from torchrl.modules.tensordict_module.common import TensorDictModule
+
+__init__ = ["TensorDictDefaultInitializer"]
+
 
 class _DefaultInitializer(nn.Module):
-
     def __init__(self):
         super().__init__()
 
@@ -32,20 +33,27 @@ class _DefaultInitializer(nn.Module):
         outputs = {}
         for key, value in initializer_dict.items():
             if "args" in value and "kwargs" in value:
-                outputs[key] = value["initializer"]( *batch_size, *value["shape"],
-                        *value["args"], **value["kwargs"], device=device
+                outputs[key] = value["initializer"](
+                    *batch_size,
+                    *value["shape"],
+                    *value["args"],
+                    **value["kwargs"],
+                    device=device,
                 )
             elif "args" in value:
-                outputs[key] = value["initializer"]( *batch_size, *value["shape"],
-                        *value["args"], device=device
+                outputs[key] = value["initializer"](
+                    *batch_size, *value["shape"], *value["args"], device=device
                 )
             elif "kwargs" in value:
-                outputs[key] = value["initializer"]( *batch_size, *value["shape"],
-                        **value["kwargs"], device=device
+                outputs[key] = value["initializer"](
+                    *batch_size, *value["shape"], **value["kwargs"], device=device
                 )
             else:
-                outputs[key] = value["initializer"]( *batch_size, *value["shape"], device=device)
+                outputs[key] = value["initializer"](
+                    *batch_size, *value["shape"], device=device
+                )
         return outputs
+
 
 class TensorDictDefaultInitializer(TensorDictModule):
     """
@@ -61,22 +69,23 @@ class TensorDictDefaultInitializer(TensorDictModule):
             and kwargs the keyword arguments to pass to the initializer function.
             the initializer function must be of the following form initializer (*batch_size, *args, **kwargs, device=device)
         reinit (bool): Whether to reinitialize already initialized tensors.
-    
+
     Returns:
         TensorDictBase: The TensorDict to whom we added the initialized tensors.
 
 
     """
+
     def __init__(
         self,
         defaults_init: Dict[Dict],
-        reinit = False,
+        reinit=False,
     ):
 
         module = _DefaultInitializer()
 
-        in_keys = []
-        out_keys = defaults_init.keys()
+        in_keys = list(defaults_init.keys())
+        out_keys = list(defaults_init.keys())
         self.reinit = reinit
 
         self.defaults_init = defaults_init


### PR DESCRIPTION
## Description

This PR adds a module that can initialize a set of tensors to default values and add it to the given TD
## Motivation and Context

This change is required because we might want to init some tensors inside of a TDSequence. For example if the td is given from an env, we can want to add some other tensors. This could require to make changes to core methods such as collectors, rollouts et... By doing this, we can directly do the change inside a TDSequence

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
