### PR TITLE
[BugFix] CatTensors: Prepended `next_` to the out_key

### DIFF
--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -1544,7 +1544,7 @@ class CatTensors(Transform):
     Args:
         keys_in (Sequence of str): keys to be concatenated
         out_key: key of the resulting tensor.
-        dim (int, optional): dimension along which the contenation will occur.
+        dim (int, optional): dimension along which the concatenation will occur.
             Default is -1.
         del_keys (bool, optional): if True, the input values will be deleted after
             concatenation. Default is True.
@@ -1575,13 +1575,15 @@ class CatTensors(Transform):
     def __init__(
         self,
         keys_in: Optional[Sequence[str]] = None,
-        out_key: str = "observation_vector",
+        out_key: str = "next_observation_vector",
         dim: int = -1,
         del_keys: bool = True,
         unsqueeze_if_oor: bool = False,
     ):
         if keys_in is None:
             raise Exception("CatTensors requires keys to be non-empty")
+        if type(out_key) != str:
+            raise Exception("CatTensors requires out_key to be of type string")
         super().__init__(keys_in=keys_in)
         if not out_key.startswith("next_") and all(
             key.startswith("next_") for key in keys_in


### PR DESCRIPTION
Bug fix for Issue #437 (CatTensors)

## Description

Prepended 'next_' to the out_key defaults, added a type check to prevent non-string inputs to out_key, and fixed a spelling mistake in the docstring


## Motivation and Context

A bug fix for #437 

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
