### PR TITLE
[Feature] Make `env.action_spec` point to `env.input_spec["action"]`

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1094,13 +1094,13 @@ class TestTransforms:
         _ = env.observation_spec
         _ = env.reward_spec
 
-        assert env._action_spec is not None
+        assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
         assert env._observation_spec is not None
         assert env._reward_spec is not None
 
         env.insert_transform(0, CatFrames(N=4, cat_dim=-1, keys_in=[key]))
 
-        assert env._action_spec is None
+        assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
         assert env._observation_spec is None
         assert env._reward_spec is None
 
@@ -1139,7 +1139,7 @@ class TestTransforms:
         assert isinstance(env.transform[2], CatFrames)
         assert isinstance(env.transform[3], NoopResetEnv)
         assert isinstance(env.transform[4], FiniteTensorDictCheck)
-        assert env._action_spec is None
+        assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
         assert env._observation_spec is None
         assert env._reward_spec is None
 
@@ -1153,7 +1153,7 @@ class TestTransforms:
         assert isinstance(env.transform[3], CatFrames)
         assert isinstance(env.transform[4], NoopResetEnv)
         assert isinstance(env.transform[5], FiniteTensorDictCheck)
-        assert env._action_spec is None
+        assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
         assert env._observation_spec is None
         assert env._reward_spec is None
 
@@ -1166,7 +1166,7 @@ class TestTransforms:
             assert 1 == 6
         except ValueError:
             assert len(env.transform) == 6
-            assert env._action_spec is not None
+            assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
             assert env._observation_spec is not None
             assert env._reward_spec is not None
 
@@ -1175,7 +1175,7 @@ class TestTransforms:
             assert 1 == 6
         except ValueError:
             assert len(env.transform) == 6
-            assert env._action_spec is not None
+            assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
             assert env._observation_spec is not None
             assert env._reward_spec is not None
 
@@ -1184,7 +1184,7 @@ class TestTransforms:
             assert 1 == 6
         except ValueError:
             assert len(env.transform) == 6
-            assert env._action_spec is not None
+            assert (env._input_spec is not None) and ("action" in env._input_spec) and (env._input_spec["action"] is not None)
             assert env._observation_spec is not None
             assert env._reward_spec is not None
 

--- a/torchrl/envs/common.py
+++ b/torchrl/envs/common.py
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
+import sys
 
 import abc
 from copy import deepcopy
@@ -200,8 +201,6 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
         self.dtype = dtype_map.get(dtype, dtype)
         if "is_closed" not in self.__dir__():
             self.is_closed = True
-        if "_action_spec" not in self.__dir__():
-            self._action_spec = None
         if "_input_spec" not in self.__dir__():
             self._input_spec = None
         if "_reward_spec" not in self.__dir__():
@@ -224,11 +223,14 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
 
     @property
     def action_spec(self) -> TensorSpec:
-        return self._action_spec
+        return self.input_spec["action"]
 
     @action_spec.setter
     def action_spec(self, value: TensorSpec) -> None:
-        self._action_spec = value
+        if self._input_spec is None:
+            self._input_spec = CompositeSpec(action=value)
+        else:
+            self._input_spec["action"] = value
 
     @property
     def input_spec(self) -> TensorSpec:
@@ -270,13 +272,6 @@ class EnvBase(nn.Module, metaclass=abc.ABCMeta):
             (+ others if needed).
 
         """
-
-        # sanity check
-        if tensordict.get("action").dtype is not self.action_spec.dtype:
-            raise TypeError(
-                f"expected action.dtype to be {self.action_spec.dtype} "
-                f"but got {tensordict.get('action').dtype}"
-            )
 
         tensordict.is_locked = True  # make sure _step does not modify the tensordict
         tensordict_out = self._step(tensordict)

--- a/torchrl/envs/libs/dm_control.py
+++ b/torchrl/envs/libs/dm_control.py
@@ -207,6 +207,7 @@ class DMControlWrapper(GymLikeEnv):
         observation = timestep_tuple[0].observation
         return observation, reward, done
 
+    # TODO: how to change _action_spec to _input_spec here?
     @property
     def action_spec(self) -> TensorSpec:
         if self._action_spec is None:

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -323,7 +323,6 @@ class TransformedEnv(EnvBase):
         self._last_obs = None
         self.cache_specs = cache_specs
 
-        self._action_spec = None
         self._reward_spec = None
         self._observation_spec = None
         self.batch_size = self.base_env.batch_size
@@ -350,15 +349,30 @@ class TransformedEnv(EnvBase):
     def action_spec(self) -> TensorSpec:
         """Action spec of the transformed_in environment"""
 
-        if self._action_spec is None or not self.cache_specs:
+        if self._input_spec is None or "action" not in self._input_spec or self._input_spec["action"] is None \
+            or not self.cache_specs:
             action_spec = self.transform.transform_action_spec(
                 deepcopy(self.base_env.action_spec)
             )
             if self.cache_specs:
-                self._action_spec = action_spec
+                if self._input_spec is None:
+                    self._input_spec = self.transform.transform_input_spec(
+                        deepcopy(self.base_env.input_spec)
+                    )
+                self._input_spec["action"] = action_spec
         else:
-            action_spec = self._action_spec
+            action_spec = self._input_spec["action"]
         return action_spec
+
+        # if self._action_spec is None or not self.cache_specs:
+        #     action_spec = self.transform.transform_action_spec(
+        #         deepcopy(self.base_env.action_spec)
+        #     )
+        #     if self.cache_specs:
+        #         self._action_spec = action_spec
+        # else:
+        #     action_spec = self._action_spec
+        # return action_spec
 
     @property
     def input_spec(self) -> TensorSpec:
@@ -450,7 +464,7 @@ class TransformedEnv(EnvBase):
 
     def empty_cache(self):
         self._observation_spec = None
-        self._action_spec = None
+        self.action_spec = None
         self._reward_spec = None
 
     def append_transform(self, transform: Transform) -> None:
@@ -504,7 +518,7 @@ class TransformedEnv(EnvBase):
 
     def _erase_metadata(self):
         if self.cache_specs:
-            self._action_spec = None
+            self.action_spec = None
             self._observation_spec = None
             self._reward_spec = None
 
@@ -516,7 +530,7 @@ class TransformedEnv(EnvBase):
         self.is_done = self.is_done.to(device)
 
         if self.cache_specs:
-            self._action_spec = None
+            self.action_spec = None
             self._observation_spec = None
             self._reward_spec = None
         return self
@@ -527,9 +541,22 @@ class TransformedEnv(EnvBase):
         if isinstance(value, Transform):
             value.set_parent(self)
         if isinstance(propobj, property):
-            if propobj.fset is None:
+            ancestors = list(__class__.__mro__)[::-1]
+            while isinstance(propobj, property):
+                if propobj.fset is not None:
+                    return propobj.fset(self, value)
+                propobj = getattr(ancestors.pop(), key, None)
+            else:
                 raise AttributeError(f"can't set attribute {key}")
-            return propobj.fset(self, value)
+
+        # if isinstance(propobj, property):
+        #     propobj = None
+        #     for cls in self.__class__.__mro__:
+        #         propobj = getattr(cls, key, None)
+        #         if 
+        #     if propobj.fset is None:
+        #         raise AttributeError(f"can't set attribute {key}")
+        #     return propobj.fset(self, value)
         else:
             return super().__setattr__(key, value)
 

--- a/torchrl/envs/vec_env.py
+++ b/torchrl/envs/vec_env.py
@@ -192,7 +192,6 @@ class _BatchedEnv(EnvBase):
                 "memmap and shared memory are mutually exclusive features."
             )
         self._batch_size = None
-        self._action_spec = None
         self._observation_spec = None
         self._reward_spec = None
         self._device = None
@@ -273,10 +272,20 @@ class _BatchedEnv(EnvBase):
     def _set_properties(self):
         if self._single_task:
             self._batch_size = self.meta_data.batch_size
-            self._action_spec = self.meta_data.specs["action_spec"]
+            # TODO create input_spec if it does not exist and set ["action"].
+            # do it further down, after checking there is not value conflicts between
+            # action_spec and inpout_spec["action"]
             self._observation_spec = self.meta_data.specs["observation_spec"]
             self._reward_spec = self.meta_data.specs["reward_spec"]
             self._input_spec = self.meta_data.specs["input_spec"]
+            if "action" in self.meta_data.specs["input_spec"] \
+                and "action_spec" in self.meta_data.specs\
+                and self.meta_data.specs["input_spec"]["action"] != self.meta_data.specs["action_spec"]:
+                raise ValueError(
+                    "meta_data.specs[\"input_spec\"][\"action_spec\"] and meta_data.specs[\"action_spec\"] "
+                    "have different values"
+                    )
+            self._input_spec["action"] = self.meta_data.specs["action_spec"]
             self._dummy_env_str = self.meta_data.env_str
             self._device = self.meta_data.device
             self._env_tensordict = self.meta_data.tensordict
@@ -286,7 +295,6 @@ class _BatchedEnv(EnvBase):
             )
             self._device = self.meta_data[0].device
             # TODO: check that all action_spec and reward spec match (issue #351)
-            self._action_spec = self.meta_data[0].specs["action_spec"]
             self._reward_spec = self.meta_data[0].specs["reward_spec"]
             self._observation_spec = {}
             for md in self.meta_data:
@@ -317,13 +325,13 @@ class _BatchedEnv(EnvBase):
 
     @property
     def action_spec(self) -> TensorSpec:
-        if self._action_spec is None:
+        if (self._input_spec is None) or ("action" not in self._input_spec) or (self._input_spec["action"] is None):
             self._set_properties()
-        return self._action_spec
+        return self._input_spec["action"]
 
     @action_spec.setter
     def action_spec(self, value: TensorSpec) -> None:
-        self._action_spec = value
+        self._input_spec["action"] = value
 
     @property
     def device(self) -> torch.device:


### PR DESCRIPTION
the action_spec property pointing to _input_spec["action"]

## Description

Describe your changes in detail.

## Motivation and Context

Close #405

- [ ] I have raised an issue to propose this change ([required](https://github.com/facebookresearch/rl/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of examples)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [ x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
