### PR TITLE
[BugFix]: Fixed dm_control action type casting

### DIFF
--- a/torchrl/trainers/helpers/envs.py
+++ b/torchrl/trainers/helpers/envs.py
@@ -152,6 +152,9 @@ def make_env_transforms(
         double_to_float_list += [
             "reward",
         ]
+        double_to_float_list += [
+            "action",
+        ]
         double_to_float_inv_list += ["action"]  # DMControl requires double-precision
     if not from_pixels:
         selected_keys = [


### PR DESCRIPTION
## Description

Re cast dm control actions back to float32

## Motivation and Context
The motivation is that we want to be able to work with float32 actions when using dm_control,


## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
