### PR TITLE
[BugFix] TransformedEnv attributes inheritance

### DIFF
--- a/test/test_transforms.py
+++ b/test/test_transforms.py
@@ -1387,7 +1387,7 @@ def test_batch_locked_transformed(device):
     td = env.reset()
     td["action"] = env.action_spec.rand(env.batch_size)
     td_expanded = td.expand(2).clone()
-    td = env.step(td)
+    env.step(td)
 
     with pytest.raises(
         RuntimeError, match="Expected a tensordict with shape==env.shape, "
@@ -1411,7 +1411,7 @@ def test_batch_unlocked_transformed(device):
     td = env.reset()
     td["action"] = env.action_spec.rand(env.batch_size)
     td_expanded = td.expand(2).clone()
-    td = env.step(td)
+    env.step(td)
     env.step(td_expanded)
 
 
@@ -1432,7 +1432,7 @@ def test_batch_unlocked_with_batch_size_transformed(device):
     td = env.reset()
     td["action"] = env.action_spec.rand(env.batch_size)
     td_expanded = td.expand(2, 2).reshape(-1).to_tensordict()
-    td = env.step(td)
+    env.step(td)
 
     with pytest.raises(
         RuntimeError, match="Expected a tensordict with shape==env.shape, "

--- a/torchrl/envs/transforms/transforms.py
+++ b/torchrl/envs/transforms/transforms.py
@@ -335,6 +335,10 @@ class TransformedEnv(EnvBase):
     def batch_locked(self) -> bool:
         return self.base_env.batch_locked
 
+    @batch_locked.setter
+    def batch_locked(self, value):
+        raise RuntimeError("batch_locked is a read-only property")
+
     @property
     def _inplace_update(self):
         return self.base_env._inplace_update


### PR DESCRIPTION
## Description

Fixes the setting of `env.batch_locked` and `env._inplace_update` for TransformedEnv, as passing them through a Pipe caused a attribute error when calling `__new__`.