### PR TITLE
[Feature] Cleanup mocking envs init and new

### DIFF
--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -109,13 +109,13 @@ class MockSerialEnv(EnvBase):
         **kwargs,
     ):
         if action_spec is None:
-            cls._action_spec = NdUnboundedContinuousTensorSpec((1,))
+            _action_spec = NdUnboundedContinuousTensorSpec((1,))
         if observation_spec is None:
-            cls._observation_spec = NdUnboundedContinuousTensorSpec((1,))
+            _observation_spec = NdUnboundedContinuousTensorSpec((1,))
         if reward_spec is None:
-            cls._reward_spec = NdUnboundedContinuousTensorSpec((1,))
+            _reward_spec = NdUnboundedContinuousTensorSpec((1,))
         if input_spec is None:
-            cls._input_spec = CompositeSpec(action=cls.action_spec)
+            _input_spec = CompositeSpec(action=cls.action_spec)
         cls._reward_spec = reward_spec
         cls._observation_spec = observation_spec
         cls._input_spec = input_spec

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -58,7 +58,7 @@ class _MockEnv(EnvBase):
         *args,
         **kwargs,
     ):
-        for key, item in list(cls.observation_spec.items()):
+        for key, item in list(cls._observation_spec.items()):
             cls._observation_spec[key] = item.to(torch.get_default_dtype())
         # cls._action_spec = cls.action_spec.to(torch.get_default_dtype())
         cls._reward_spec = cls.reward_spec.to(torch.get_default_dtype())

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -115,7 +115,7 @@ class MockSerialEnv(EnvBase):
         if reward_spec is None:
             reward_spec = NdUnboundedContinuousTensorSpec((1,))
         if input_spec is None:
-            input_spec = CompositeSpec(action=cls.action_spec)
+            input_spec = CompositeSpec(action=action_spec)
         cls._reward_spec = reward_spec
         cls._observation_spec = observation_spec
         cls._input_spec = input_spec
@@ -266,6 +266,7 @@ class DiscreteActionVecMockEnv(_MockEnv):
         action_spec=None,
         input_spec=None,
         reward_spec=None,
+        from_pixels=False,
         **kwargs,
     ):
         size = cls.size = 7
@@ -284,8 +285,6 @@ class DiscreteActionVecMockEnv(_MockEnv):
         if reward_spec is None:
             reward_spec = UnboundedContinuousTensorSpec()
 
-        cls.from_pixels = False
-
         if input_spec is None:
             cls._out_key = "observation_orig"
             input_spec = CompositeSpec(
@@ -298,6 +297,7 @@ class DiscreteActionVecMockEnv(_MockEnv):
         cls._observation_spec = observation_spec
         cls._input_spec = input_spec
         cls._action_spec = action_spec
+        cls.from_pixels = from_pixels
         return super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):
@@ -351,6 +351,7 @@ class ContinuousActionVecMockEnv(_MockEnv):
         action_spec=None,
         input_spec=None,
         reward_spec=None,
+        from_pixels=False,
         **kwargs,
     ):
         size = cls.size = 7
@@ -368,7 +369,6 @@ class ContinuousActionVecMockEnv(_MockEnv):
             action_spec = NdBoundedTensorSpec(-1, 1, (7,))
         if reward_spec is None:
             reward_spec = UnboundedContinuousTensorSpec()
-        cls.from_pixels = False
 
         if input_spec is None:
             cls._out_key = "observation_orig"
@@ -382,6 +382,7 @@ class ContinuousActionVecMockEnv(_MockEnv):
         cls._observation_spec = observation_spec
         cls._input_spec = input_spec
         cls._action_spec = action_spec
+        cls.from_pixels = from_pixels
         return super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):
@@ -455,6 +456,7 @@ class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
         action_spec=None,
         input_spec=None,
         reward_spec=None,
+        from_pixels=True,
         **kwargs,
     ):
         if observation_spec is None:
@@ -471,7 +473,6 @@ class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
             action_spec = OneHotDiscreteTensorSpec(7)
         if reward_spec is None:
             reward_spec = UnboundedContinuousTensorSpec()
-        cls.from_pixels = True
 
         if input_spec is None:
             cls._out_key = "pixels_orig"
@@ -487,6 +488,7 @@ class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
             action_spec=action_spec,
             reward_spec=reward_spec,
             input_spec=input_spec,
+            from_pixels=from_pixels,
             **kwargs,
         )
 
@@ -507,6 +509,7 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
         action_spec=None,
         input_spec=None,
         reward_spec=None,
+        from_pixels=True,
         **kwargs,
     ):
         if observation_spec is None:
@@ -530,13 +533,13 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
                 }
             )
 
-        cls.from_pixels = True
         return super().__new__(
             *args,
             observation_spec=observation_spec,
             action_spec=action_spec,
             reward_spec=reward_spec,
             input_spec=input_spec,
+            from_pixels=from_pixels,
             **kwargs,
         )
 
@@ -553,6 +556,7 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
 
 
 class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
+    @classmethod
     def __new__(
         cls,
         *args,
@@ -560,6 +564,7 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
         action_spec=None,
         input_spec=None,
         reward_spec=None,
+        from_pixels=True,
         **kwargs,
     ):
         if observation_spec is None:
@@ -578,7 +583,6 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
 
         if reward_spec is None:
             reward_spec = UnboundedContinuousTensorSpec()
-        cls.from_pixels = True
         if input_spec is None:
             cls._out_key = "pixels_orig"
             input_spec = CompositeSpec(
@@ -590,6 +594,7 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
             action_spec=action_spec,
             reward_spec=reward_spec,
             input_spec=input_spec,
+            from_pixels=from_pixels,
             **kwargs,
         )
 
@@ -602,11 +607,36 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
 
 
 class ContinuousActionConvMockEnvNumpy(ContinuousActionConvMockEnv):
-    observation_spec = CompositeSpec(
-        next_pixels=NdUnboundedContinuousTensorSpec(shape=torch.Size([7, 7, 3])),
-        next_pixels_orig=NdUnboundedContinuousTensorSpec(shape=torch.Size([7, 7, 3])),
-    )
-    from_pixels = True
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        from_pixels=True,
+        **kwargs,
+    ):
+        if observation_spec is None:
+            cls.out_key = "pixels"
+            observation_spec = CompositeSpec(
+                next_pixels=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([7, 7, 3])
+                ),
+                next_pixels_orig=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([7, 7, 3])
+                ),
+            )
+        return super().__new__(
+            *args,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            input_spec=input_spec,
+            from_pixels=from_pixels,
+            **kwargs,
+        )
 
     def _get_out_obs(self, obs):
         obs = torch.diag_embed(obs, 0, -2, -1).unsqueeze(-1)

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -52,6 +52,18 @@ def make_spec(spec_str):
 
 
 class _MockEnv(EnvBase):
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        **kwargs,
+    ):
+        for key, item in list(cls.observation_spec.items()):
+            cls.observation_spec[key] = item.to(torch.get_default_dtype())
+        # cls.action_spec = cls.action_spec.to(torch.get_default_dtype())
+        cls.reward_spec = cls.reward_spec.to(torch.get_default_dtype())
+        return super().__new__(*args, **kwargs)
+
     def __init__(self, seed: int = 100):
         super().__init__(
             device="cpu",
@@ -59,11 +71,6 @@ class _MockEnv(EnvBase):
         )
         self.set_seed(seed)
         self.is_closed = False
-
-        for key, item in list(self.observation_spec.items()):
-            self.observation_spec[key] = item.to(torch.get_default_dtype())
-        # self.action_spec = self.action_spec.to(torch.get_default_dtype())
-        self.reward_spec = self.reward_spec.to(torch.get_default_dtype())
 
     @property
     def maxstep(self):
@@ -91,11 +98,32 @@ class _MockEnv(EnvBase):
 
 
 class MockSerialEnv(EnvBase):
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        if action_spec is None:
+            cls.action_spec = NdUnboundedContinuousTensorSpec((1,))
+        if observation_spec is None:
+            cls.observation_spec = NdUnboundedContinuousTensorSpec((1,))
+        if reward_spec is None:
+            cls.reward_spec = NdUnboundedContinuousTensorSpec((1,))
+        if input_spec is None:
+            cls.input_spec = CompositeSpec(action=cls.action_spec)
+        cls.reward_spec = reward_spec
+        cls.observation_spec = observation_spec
+        cls.input_spec = input_spec
+        cls.action_spec = action_spec
+        return super().__new__(*args, **kwargs)
+
     def __init__(self, device):
         super(MockSerialEnv, self).__init__(device=device)
-        self.action_spec = NdUnboundedContinuousTensorSpec((1,))
-        self.observation_spec = NdUnboundedContinuousTensorSpec((1,))
-        self.reward_spec = NdUnboundedContinuousTensorSpec((1,))
         self.is_closed = False
 
     def set_seed(self, seed: int, static_seed: bool = False) -> int:
@@ -135,17 +163,41 @@ class MockSerialEnv(EnvBase):
 class MockBatchedLockedEnv(EnvBase):
     """Mocks an env whose batch_size defines the size of the output tensordict"""
 
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        if action_spec is None:
+            action_spec = NdUnboundedContinuousTensorSpec((1,))
+        if action_spec is None:
+            input_spec = CompositeSpec(
+                action=NdUnboundedContinuousTensorSpec((1,)),
+                observation=NdUnboundedContinuousTensorSpec((1,)),
+            )
+        if observation_spec is None:
+            observation_spec = CompositeSpec(
+                next_observation=NdUnboundedContinuousTensorSpec((1,))
+            )
+        if reward_spec is None:
+            reward_spec = NdUnboundedContinuousTensorSpec((1,))
+        cls.reward_spec = reward_spec
+        cls.observation_spec = observation_spec
+        cls.input_spec = input_spec
+        cls.action_spec = action_spec
+        return super().__new__(
+            cls,
+            *args,
+            **kwargs,
+        )
+
     def __init__(self, device, batch_size=None):
         super(MockBatchedLockedEnv, self).__init__(device=device, batch_size=batch_size)
-        self.action_spec = NdUnboundedContinuousTensorSpec((1,))
-        self.input_spec = CompositeSpec(
-            action=NdUnboundedContinuousTensorSpec((1,)),
-            observation=NdUnboundedContinuousTensorSpec((1,)),
-        )
-        self.observation_spec = CompositeSpec(
-            next_observation=NdUnboundedContinuousTensorSpec((1,))
-        )
-        self.reward_spec = NdUnboundedContinuousTensorSpec((1,))
         self.counter = 0
 
     set_seed = MockSerialEnv.set_seed
@@ -206,21 +258,47 @@ class MockBatchedUnLockedEnv(MockBatchedLockedEnv):
 
 
 class DiscreteActionVecMockEnv(_MockEnv):
-    size = 7
-    observation_spec = CompositeSpec(
-        next_observation=NdUnboundedContinuousTensorSpec(shape=torch.Size([size])),
-        next_observation_orig=NdUnboundedContinuousTensorSpec(shape=torch.Size([size])),
-    )
-    action_spec = OneHotDiscreteTensorSpec(7)
-    reward_spec = UnboundedContinuousTensorSpec()
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        size = cls.size = 7
+        if observation_spec is None:
+            cls.out_key = "observation"
+            observation_spec = CompositeSpec(
+                next_observation=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([size])
+                ),
+                next_observation_orig=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([size])
+                ),
+            )
+        if action_spec is None:
+            action_spec = OneHotDiscreteTensorSpec(7)
+        if reward_spec is None:
+            reward_spec = UnboundedContinuousTensorSpec()
 
-    from_pixels = False
+        cls.from_pixels = False
 
-    out_key = "observation"
-    _out_key = "observation_orig"
-    input_spec = CompositeSpec(
-        **{_out_key: observation_spec["next_observation"], "action": action_spec}
-    )
+        if input_spec is None:
+            cls._out_key = "observation_orig"
+            input_spec = CompositeSpec(
+                **{
+                    cls._out_key: observation_spec["next_observation"],
+                    "action": action_spec,
+                }
+            )
+        cls.reward_spec = reward_spec
+        cls.observation_spec = observation_spec
+        cls.input_spec = input_spec
+        cls.action_spec = action_spec
+        return super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):
         return obs
@@ -265,20 +343,46 @@ class DiscreteActionVecMockEnv(_MockEnv):
 
 
 class ContinuousActionVecMockEnv(_MockEnv):
-    size = 7
-    observation_spec = CompositeSpec(
-        next_observation=NdUnboundedContinuousTensorSpec(shape=torch.Size([size])),
-        next_observation_orig=NdUnboundedContinuousTensorSpec(shape=torch.Size([size])),
-    )
-    action_spec = NdBoundedTensorSpec(-1, 1, (7,))
-    reward_spec = UnboundedContinuousTensorSpec()
-    from_pixels = False
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        size = cls.size = 7
+        if observation_spec is None:
+            cls.out_key = "observation"
+            observation_spec = CompositeSpec(
+                next_observation=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([size])
+                ),
+                next_observation_orig=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([size])
+                ),
+            )
+        if action_spec is None:
+            action_spec = NdBoundedTensorSpec(-1, 1, (7,))
+        if reward_spec is None:
+            reward_spec = UnboundedContinuousTensorSpec()
+        cls.from_pixels = False
 
-    out_key = "observation"
-    _out_key = "observation_orig"
-    input_spec = CompositeSpec(
-        **{_out_key: observation_spec["next_observation"], "action": action_spec}
-    )
+        if input_spec is None:
+            cls._out_key = "observation_orig"
+            input_spec = CompositeSpec(
+                **{
+                    cls._out_key: observation_spec["next_observation"],
+                    "action": action_spec,
+                }
+            )
+        cls.reward_spec = reward_spec
+        cls.observation_spec = observation_spec
+        cls.input_spec = input_spec
+        cls.action_spec = action_spec
+        super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):
         return obs
@@ -343,19 +447,48 @@ class DiscreteActionVecPolicy:
 
 
 class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
-    observation_spec = CompositeSpec(
-        next_pixels=NdUnboundedContinuousTensorSpec(shape=torch.Size([1, 7, 7])),
-        next_pixels_orig=NdUnboundedContinuousTensorSpec(shape=torch.Size([1, 7, 7])),
-    )
-    action_spec = OneHotDiscreteTensorSpec(7)
-    reward_spec = UnboundedContinuousTensorSpec()
-    from_pixels = True
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        if observation_spec is None:
+            cls.out_key = "pixels"
+            observation_spec = CompositeSpec(
+                next_pixels=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([1, 7, 7])
+                ),
+                next_pixels_orig=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([1, 7, 7])
+                ),
+            )
+        if action_spec is None:
+            action_spec = OneHotDiscreteTensorSpec(7)
+        if reward_spec is None:
+            reward_spec = UnboundedContinuousTensorSpec()
+        cls.from_pixels = True
 
-    out_key = "pixels"
-    _out_key = "pixels_orig"
-    input_spec = CompositeSpec(
-        **{_out_key: observation_spec["next_pixels_orig"], "action": action_spec}
-    )
+        if input_spec is None:
+            cls._out_key = "pixels_orig"
+            input_spec = CompositeSpec(
+                **{
+                    cls._out_key: observation_spec["next_pixels_orig"],
+                    "action": action_spec,
+                }
+            )
+        return super().__new__(
+            *args,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            input_spec=input_spec,
+            **kwargs,
+        )
 
     def _get_out_obs(self, obs):
         obs = torch.diag_embed(obs, 0, -2, -1).unsqueeze(0)
@@ -366,18 +499,46 @@ class DiscreteActionConvMockEnv(DiscreteActionVecMockEnv):
 
 
 class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
-    observation_spec = CompositeSpec(
-        next_pixels=NdUnboundedContinuousTensorSpec(shape=torch.Size([7, 7, 3])),
-        next_pixels_orig=NdUnboundedContinuousTensorSpec(shape=torch.Size([7, 7, 3])),
-    )
-    action_spec = OneHotDiscreteTensorSpec(7)
-    out_key = "pixels"
-    _out_key = "pixels_orig"
-    input_spec = CompositeSpec(
-        **{_out_key: observation_spec["next_pixels_orig"], "action": action_spec}
-    )
+    @classmethod
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        if observation_spec is None:
+            cls.out_key = "pixels"
+            observation_spec = CompositeSpec(
+                next_pixels=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([7, 7, 3])
+                ),
+                next_pixels_orig=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([7, 7, 3])
+                ),
+            )
+        if action_spec is None:
+            action_spec = OneHotDiscreteTensorSpec(7)
+        if input_spec is None:
+            cls._out_key = "pixels_orig"
+            input_spec = CompositeSpec(
+                **{
+                    cls._out_key: observation_spec["next_pixels_orig"],
+                    "action": action_spec,
+                }
+            )
 
-    from_pixels = True
+        cls.from_pixels = True
+        super().__new__(
+            *args,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            input_spec=input_spec,
+            **kwargs,
+        )
 
     def _get_out_obs(self, obs):
         obs = torch.diag_embed(obs, 0, -2, -1).unsqueeze(-1)
@@ -392,19 +553,45 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
 
 
 class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
-    observation_spec = CompositeSpec(
-        next_pixels=NdUnboundedContinuousTensorSpec(shape=torch.Size([1, 7, 7])),
-        next_pixels_orig=NdUnboundedContinuousTensorSpec(shape=torch.Size([1, 7, 7])),
-    )
-    action_spec = NdBoundedTensorSpec(-1, 1, (7,))
-    reward_spec = UnboundedContinuousTensorSpec()
-    from_pixels = True
+    def __new__(
+        cls,
+        *args,
+        observation_spec=None,
+        action_spec=None,
+        input_spec=None,
+        reward_spec=None,
+        **kwargs,
+    ):
+        if observation_spec is None:
+            cls.out_key = "pixels"
+            observation_spec = CompositeSpec(
+                next_pixels=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([1, 7, 7])
+                ),
+                next_pixels_orig=NdUnboundedContinuousTensorSpec(
+                    shape=torch.Size([1, 7, 7])
+                ),
+            )
 
-    out_key = "pixels"
-    _out_key = "pixels_orig"
-    input_spec = CompositeSpec(
-        **{_out_key: observation_spec["next_pixels"], "action": action_spec}
-    )
+        if action_spec is None:
+            action_spec = NdBoundedTensorSpec(-1, 1, (7,))
+
+        if reward_spec is None:
+            reward_spec = UnboundedContinuousTensorSpec()
+        cls.from_pixels = True
+        if input_spec is None:
+            cls._out_key = "pixels_orig"
+            input_spec = CompositeSpec(
+                **{cls._out_key: observation_spec["next_pixels"], "action": action_spec}
+            )
+        super().__new__(
+            *args,
+            observation_spec=observation_spec,
+            action_spec=action_spec,
+            reward_spec=reward_spec,
+            input_spec=input_spec,
+            **kwargs,
+        )
 
     def _get_out_obs(self, obs):
         obs = torch.diag_embed(obs, 0, -2, -1).unsqueeze(0)

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -59,7 +59,7 @@ class _MockEnv(EnvBase):
         **kwargs,
     ):
         for key, item in list(cls.observation_spec.items()):
-            cls.observation_spec[key] = item.to(torch.get_default_dtype())
+            cls._observation_spec[key] = item.to(torch.get_default_dtype())
         # cls._action_spec = cls.action_spec.to(torch.get_default_dtype())
         cls._reward_spec = cls.reward_spec.to(torch.get_default_dtype())
         return super().__new__(*args, **kwargs)

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -109,13 +109,13 @@ class MockSerialEnv(EnvBase):
         **kwargs,
     ):
         if action_spec is None:
-            _action_spec = NdUnboundedContinuousTensorSpec((1,))
+            action_spec = NdUnboundedContinuousTensorSpec((1,))
         if observation_spec is None:
-            _observation_spec = NdUnboundedContinuousTensorSpec((1,))
+            observation_spec = NdUnboundedContinuousTensorSpec((1,))
         if reward_spec is None:
-            _reward_spec = NdUnboundedContinuousTensorSpec((1,))
+            reward_spec = NdUnboundedContinuousTensorSpec((1,))
         if input_spec is None:
-            _input_spec = CompositeSpec(action=cls.action_spec)
+            input_spec = CompositeSpec(action=cls.action_spec)
         cls._reward_spec = reward_spec
         cls._observation_spec = observation_spec
         cls._input_spec = input_spec

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -382,7 +382,7 @@ class ContinuousActionVecMockEnv(_MockEnv):
         cls._observation_spec = observation_spec
         cls._input_spec = input_spec
         cls._action_spec = action_spec
-        super().__new__(*args, **kwargs)
+        return super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):
         return obs
@@ -531,7 +531,7 @@ class DiscreteActionConvMockEnvNumpy(DiscreteActionConvMockEnv):
             )
 
         cls.from_pixels = True
-        super().__new__(
+        return super().__new__(
             *args,
             observation_spec=observation_spec,
             action_spec=action_spec,
@@ -584,7 +584,7 @@ class ContinuousActionConvMockEnv(ContinuousActionVecMockEnv):
             input_spec = CompositeSpec(
                 **{cls._out_key: observation_spec["next_pixels"], "action": action_spec}
             )
-        super().__new__(
+        return super().__new__(
             *args,
             observation_spec=observation_spec,
             action_spec=action_spec,

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -61,7 +61,7 @@ class _MockEnv(EnvBase):
         for key, item in list(cls._observation_spec.items()):
             cls._observation_spec[key] = item.to(torch.get_default_dtype())
         # cls._action_spec = cls.action_spec.to(torch.get_default_dtype())
-        cls._reward_spec = cls.reward_spec.to(torch.get_default_dtype())
+        cls._reward_spec = cls._reward_spec.to(torch.get_default_dtype())
         return super().__new__(*args, **kwargs)
 
     def __init__(self, seed: int = 100):

--- a/test/mocking_classes.py
+++ b/test/mocking_classes.py
@@ -60,8 +60,8 @@ class _MockEnv(EnvBase):
     ):
         for key, item in list(cls.observation_spec.items()):
             cls.observation_spec[key] = item.to(torch.get_default_dtype())
-        # cls.action_spec = cls.action_spec.to(torch.get_default_dtype())
-        cls.reward_spec = cls.reward_spec.to(torch.get_default_dtype())
+        # cls._action_spec = cls.action_spec.to(torch.get_default_dtype())
+        cls._reward_spec = cls.reward_spec.to(torch.get_default_dtype())
         return super().__new__(*args, **kwargs)
 
     def __init__(self, seed: int = 100):
@@ -109,17 +109,17 @@ class MockSerialEnv(EnvBase):
         **kwargs,
     ):
         if action_spec is None:
-            cls.action_spec = NdUnboundedContinuousTensorSpec((1,))
+            cls._action_spec = NdUnboundedContinuousTensorSpec((1,))
         if observation_spec is None:
-            cls.observation_spec = NdUnboundedContinuousTensorSpec((1,))
+            cls._observation_spec = NdUnboundedContinuousTensorSpec((1,))
         if reward_spec is None:
-            cls.reward_spec = NdUnboundedContinuousTensorSpec((1,))
+            cls._reward_spec = NdUnboundedContinuousTensorSpec((1,))
         if input_spec is None:
-            cls.input_spec = CompositeSpec(action=cls.action_spec)
-        cls.reward_spec = reward_spec
-        cls.observation_spec = observation_spec
-        cls.input_spec = input_spec
-        cls.action_spec = action_spec
+            cls._input_spec = CompositeSpec(action=cls.action_spec)
+        cls._reward_spec = reward_spec
+        cls._observation_spec = observation_spec
+        cls._input_spec = input_spec
+        cls._action_spec = action_spec
         return super().__new__(*args, **kwargs)
 
     def __init__(self, device):
@@ -186,10 +186,10 @@ class MockBatchedLockedEnv(EnvBase):
             )
         if reward_spec is None:
             reward_spec = NdUnboundedContinuousTensorSpec((1,))
-        cls.reward_spec = reward_spec
-        cls.observation_spec = observation_spec
-        cls.input_spec = input_spec
-        cls.action_spec = action_spec
+        cls._reward_spec = reward_spec
+        cls._observation_spec = observation_spec
+        cls._input_spec = input_spec
+        cls._action_spec = action_spec
         return super().__new__(
             cls,
             *args,
@@ -294,10 +294,10 @@ class DiscreteActionVecMockEnv(_MockEnv):
                     "action": action_spec,
                 }
             )
-        cls.reward_spec = reward_spec
-        cls.observation_spec = observation_spec
-        cls.input_spec = input_spec
-        cls.action_spec = action_spec
+        cls._reward_spec = reward_spec
+        cls._observation_spec = observation_spec
+        cls._input_spec = input_spec
+        cls._action_spec = action_spec
         return super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):
@@ -378,10 +378,10 @@ class ContinuousActionVecMockEnv(_MockEnv):
                     "action": action_spec,
                 }
             )
-        cls.reward_spec = reward_spec
-        cls.observation_spec = observation_spec
-        cls.input_spec = input_spec
-        cls.action_spec = action_spec
+        cls._reward_spec = reward_spec
+        cls._observation_spec = observation_spec
+        cls._input_spec = input_spec
+        cls._action_spec = action_spec
         super().__new__(*args, **kwargs)
 
     def _get_in_obs(self, obs):

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -66,8 +66,8 @@ def make_policy(env):
         raise NotImplementedError
 
 
-@pytest.mark.parametrize("num_env", [3, 1])
-@pytest.mark.parametrize("env_name", ["vec", "conv"])
+@pytest.mark.parametrize("num_env", [1, 3])
+@pytest.mark.parametrize("env_name", ["conv", "vec"])
 def test_concurrent_collector_consistency(num_env, env_name, seed=40):
     if num_env == 1:
 

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -86,8 +86,6 @@ def test_concurrent_collector_consistency(num_env, env_name, seed=40):
             )
             return env
 
-    env = env_fn(seed)
-
     policy = make_policy(env_name)
 
     collector = SyncDataCollector(

--- a/test/test_collector.py
+++ b/test/test_collector.py
@@ -86,6 +86,8 @@ def test_concurrent_collector_consistency(num_env, env_name, seed=40):
             )
             return env
 
+    env = env_fn(seed)
+
     policy = make_policy(env_name)
 
     collector = SyncDataCollector(

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -101,7 +101,7 @@ def test_dqn_maker(device, noisy, distributional, from_pixels):
 
 @pytest.mark.skipif(not _has_gym, reason="No gym library found")
 @pytest.mark.parametrize("device", get_available_devices())
-@pytest.mark.parametrize("from_pixels", [tuple(), ("from_pixels=True", "catframes=4")])
+@pytest.mark.parametrize("from_pixels", [("from_pixels=True", "catframes=4"), tuple()])
 @pytest.mark.parametrize("gsde", [tuple(), ("gSDE=True",)])
 @pytest.mark.parametrize("exploration", ["random", "mode"])
 def test_ddpg_maker(device, from_pixels, gsde, exploration):


### PR DESCRIPTION
## Description

Cleans up the instantiation of mocking envs to use `__new__` and `__init__` more consistantly