### PR TITLE
[BugFix] Fixed pip install (https://github.com/facebookresearch/rl/issues/451)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 #[tool.usort]
 
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+
 first_party_detection = false
 
 target-version = ["py38"]


### PR DESCRIPTION
## Description

This PR fixes the dependency issue of pip install

## Motivation and Context
pip install -e . does not find torch module, issue link:
[https://github.com/facebookresearch/rl/issues/451](url)
The reason behind this is pip creates an isolated environment to build packages, currently there's no build-system section in pyproject.toml, so it'll assume to have the following backend settings:
[build-system]
requires = ["setuptools>=40.8.0", "wheel"]
build-backend = "setuptools.build_meta:__legacy__"
This PR fix the issue by adding build-system section to pyproject.toml
reference: [https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/](url)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
