### PR TITLE
[Feature]: Deactivate typechecks in envs

### DIFF
--- a/torchrl/envs/model_based/common.py
+++ b/torchrl/envs/model_based/common.py
@@ -97,6 +97,7 @@ class ModelBasedEnvBase(EnvBase, metaclass=abc.ABCMeta):
         device (torch.device, optional): device where the env input and output are expected to live
         dtype (torch.dtype, optional): dtype of the env input and output
         batch_size (torch.Size, optional): number of environments contained in the instance
+        run_type_check (bool, optional): whether to run type checks on the step of the env
 
     Methods:
         step (TensorDict -> TensorDict): step in the environment
@@ -116,9 +117,10 @@ class ModelBasedEnvBase(EnvBase, metaclass=abc.ABCMeta):
         device: DEVICE_TYPING = "cpu",
         dtype: Optional[Union[torch.dtype, np.dtype]] = None,
         batch_size: Optional[torch.Size] = None,
+        run_type_checks: bool = False,
     ):
         super(ModelBasedEnvBase, self).__init__(
-            device=device, dtype=dtype, batch_size=batch_size, run_type_checks=False
+            device=device, dtype=dtype, batch_size=batch_size, run_type_checks=run_type_checks
         )
         self.world_model = world_model.to(self.device)
         self.world_model_params = params

--- a/torchrl/envs/model_based/common.py
+++ b/torchrl/envs/model_based/common.py
@@ -120,7 +120,10 @@ class ModelBasedEnvBase(EnvBase, metaclass=abc.ABCMeta):
         run_type_checks: bool = False,
     ):
         super(ModelBasedEnvBase, self).__init__(
-            device=device, dtype=dtype, batch_size=batch_size, run_type_checks=run_type_checks
+            device=device,
+            dtype=dtype,
+            batch_size=batch_size,
+            run_type_checks=run_type_checks,
         )
         self.world_model = world_model.to(self.device)
         self.world_model_params = params

--- a/torchrl/envs/model_based/common.py
+++ b/torchrl/envs/model_based/common.py
@@ -118,7 +118,7 @@ class ModelBasedEnvBase(EnvBase, metaclass=abc.ABCMeta):
         batch_size: Optional[torch.Size] = None,
     ):
         super(ModelBasedEnvBase, self).__init__(
-            device=device, dtype=dtype, batch_size=batch_size
+            device=device, dtype=dtype, batch_size=batch_size, run_type_checks=False
         )
         self.world_model = world_model.to(self.device)
         self.world_model_params = params


### PR DESCRIPTION
## Description

Allows to deactivate typechecks in envs
## Motivation and Context

We want to be able to deactivates typechecks since it can block code execution when the dtype gets changes (ex autocast to float16)

## Types of changes

What types of changes does your code introduce? Remove all that do not apply:

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/facebookresearch/rl/blob/main/CONTRIBUTING.md) guide (**required**)
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
